### PR TITLE
feat(front): Add apikey input form

### DIFF
--- a/web/src/assets/main.scss
+++ b/web/src/assets/main.scss
@@ -86,6 +86,7 @@
 
 /* ------------------------------ Buttons ------------------------------ */
 
+.btn,
 .btn.btn-primary:not([class^='btn-outline']):not([class*=' btn-outline']):not([class^='btn-ghost']):not([class*=' btn-ghost']):not(:focus):not(.focus),
 .btn.btn-primary:not([class^='btn-outline']):not([class*=' btn-outline']):not([class^='btn-ghost']):not([class*=' btn-ghost']):not(.btn-secondary) {
   @include themify($themes) {

--- a/web/src/ui/components/ApiKeyPrompt.js
+++ b/web/src/ui/components/ApiKeyPrompt.js
@@ -1,0 +1,37 @@
+import React, {useState, useRef, useEffect} from 'react';
+
+const ApiKeyPrompt = ({failedKey, setApiKey: submitNewApiKey}) => {
+  const [formApiKey, updateFormApiKey] = useState(failedKey);
+  const inputEl = useRef(null);
+  useEffect(() => inputEl.current.focus());
+
+  return (
+    <section>
+      <div className="form-group">
+        <div className="input mt-3 mb-3">
+          <input
+            ref={inputEl}
+            type="text"
+            className="form-control"
+            placeholder={
+              'Current key: ' +
+              (failedKey || process.env.YOLO_APP_PW || 'no key set')
+            }
+            onChange={(e) => {
+              updateFormApiKey(e.target.value);
+            }}
+          />
+        </div>
+        <button
+          className="btn"
+          onClick={() => submitNewApiKey(formApiKey)}
+          disabled={!formApiKey}
+        >
+          Update
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ApiKeyPrompt;

--- a/web/src/ui/pages/Home.js
+++ b/web/src/ui/pages/Home.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import BuildList from '../components/BuildList';
 
 import './Home.scss';
@@ -11,6 +11,10 @@ const PLATFORMS = {
 
 const Home = () => {
   const [platformId, setPlatformId] = useState(PLATFORMS.none);
+  const [apiKey, setApiKey] = useState(`${process.env.YOLO_APP_PW || ''}`);
+  const updateApiKey = (key) => {
+    return setApiKey(key);
+  };
 
   return (
     <div className="container mt-3">
@@ -33,11 +37,22 @@ const Home = () => {
           <option value={PLATFORMS.android}>Android</option>
         </select>
       </div>
+      {/* TODO: Factor */}
       {platformId === PLATFORMS.android && (
-        <BuildList platformName="Android" platformId={PLATFORMS.android} />
+        <BuildList
+          platformName="Android"
+          platformId={PLATFORMS.android}
+          apiKey={apiKey}
+          setApiKey={updateApiKey}
+        />
       )}
       {platformId === PLATFORMS.iOS && (
-        <BuildList platformName="iOS" platformId={PLATFORMS.iOS} />
+        <BuildList
+          platformName="iOS"
+          platformId={PLATFORMS.iOS}
+          apiKey={apiKey}
+          setApiKey={updateApiKey}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
On 401 response from server, display error message and apiKey prompt.

** To test: `cd ./web && npm i && YOLO_APP_PW=badkey npm run start` **

(⬆️ will be updated when I find how to use Netlify)

Closes #57 