### PR TITLE
test(web): Use faker to generate mock data

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6492,6 +6492,12 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "3.0.0",
     "eslint-watch": "6.0.1",
+    "faker": "^4.1.0",
     "file-loader": "6.0.0",
     "hard-source-webpack-plugin": "0.13.1",
     "history": "4.10.1",

--- a/web/src/assets/faker.js
+++ b/web/src/assets/faker.js
@@ -1,0 +1,73 @@
+var faker = require('faker');
+
+let builds = [];
+
+const artifactStates = ['Finished'];
+const artifactKinds = ['IPA', 'APK', 'DMG'];
+const artifactDrivers = ['Buildkite'];
+const artifactMimeTypes = ['application/octet-stream'];
+const buildStates = ['Passed'];
+
+const getUrls = (artifactUrl) => ({
+  dl_artifact_signed_url: `${artifactUrl}?sign=${alphaNumeric(40)}`,
+  plist_signed_url: `${artifactUrl}.plist?sign=${alphaNumeric(40)}`,
+});
+
+const newArtifactUrl = () =>
+  `/api/artifact-${alphaNumeric({
+    min: 2,
+    max: 4,
+  })}/${arrayElement(artifactDrivers)}/${faker.random.uuid()}`;
+
+const {
+  random: {arrayElement, alphaNumeric},
+  lorem: {slug},
+} = faker;
+
+const artifact = (
+  {creationDate, driver} = {creationDate: new Date(), driver: 'Buildkite'}
+) => ({
+  id: `${driver.toLowerCase()}_${faker.lorem.slug()}`,
+  created_at: creationDate.toISOString(),
+  file_size: `${faker.random.number({min: 1234567, max: 12345678})}`,
+  local_path: `js/packages/${slug()}/${slug(10)}.ipa`,
+  download_url: `https://api.${driver.toLowerCase()}.com/v2/organizations/org/suborg/division/${faker.random.number(
+    {min: 0, max: 10}
+  )}/${faker.random.word()}/${faker.random.uuid()}/download`,
+  mime_type: `${arrayElement(artifactMimeTypes)}`,
+  state: `${arrayElement(artifactStates)}`,
+  kind: `${arrayElement(artifactKinds)}`,
+  driver: `${arrayElement(artifactDrivers)}`,
+  ...getUrls(newArtifactUrl()),
+});
+
+for (let i = 0; i < 10; i++) {
+  // stagger build times
+  let creationDate = new Date();
+  creationDate.setHours(creationDate.getHours() - (i + 1 * 6));
+  let startDate = new Date(creationDate);
+  startDate.setHours(creationDate.getHours() + 1);
+  let finishDate = new Date(creationDate);
+  finishDate.setHours(creationDate.getHours() + 3);
+
+  const driver = arrayElement(artifactDrivers);
+
+  builds = builds.concat({
+    id: `${faker.internet.url()}/org/project/meta/builds/${faker.random.alphaNumeric(
+      20
+    )}`,
+    created_at: creationDate.toISOString(),
+    state: `${arrayElement(buildStates)}`,
+    message: `${faker.lorem.sentence(10, 3)}`,
+    started_at: startDate.toISOString(),
+    finished_at: finishDate.toISOString(),
+    commit: `${alphaNumeric(40)}`,
+    branch: `${alphaNumeric(5)}:${alphaNumeric(5)}/${faker.lorem.slug()}}`,
+    driver,
+    has_artifacts: new Array(faker.random.number(5))
+      .fill(0)
+      .map(() => artifact({creationDate, driver})),
+  });
+}
+
+export const response = {status: 200, statusText: 'OK', data: {builds}};

--- a/web/src/ui/components/BuildList.js
+++ b/web/src/ui/components/BuildList.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import Card from './Card';
 import axios from 'axios';
-import {results} from '../../assets/sample-build-response';
+import {response} from '../../assets/faker.js';
 import ApiKeyPrompt from './ApiKeyPrompt';
 import {has} from 'lodash';
 
@@ -18,7 +18,7 @@ const BuildList = ({platformName, platformId, apiKey, setApiKey}) => {
     setIsLoaded(false);
     const source = () =>
       process.env.YOLO_UI_TEST === 'true'
-        ? Promise.resolve(results)
+        ? Promise.resolve(response)
         : axios.get(
             `${process.env.API_URL}/build-list?artifact_kind=${platformId}&`,
             {
@@ -45,13 +45,9 @@ const BuildList = ({platformName, platformId, apiKey, setApiKey}) => {
         },
         (error) => {
           setIsLoaded(true);
-          const status = has(error, 'response.status')
-            ? error.response.status
-            : 0;
-          const message = has(error, 'response.statusText')
-            ? error.response.statusText
-            : error.message || 'Unknown error';
-
+          const {
+            response: {statusText: message, status},
+          } = error;
           setError({message, status});
           if (status === 401) setApiKeyValidity(false);
         }


### PR DESCRIPTION
If buildtime variable `YOLO_UI_TEST` and is set to `true`, request for data will return mocked response with data generated by `faker.js` using faker library.

The purpose is to be able to quickly generate/configure mock API response 
* to avoid making pointless requests to server for style updates
* to avoid having to configure authentification
* to keep data structures transparent for frontend contributors
* to provide an easy interface (`faker.js` file) to simulate various data response scenarios (field value length/typing, increasing nhits, etc)

**To test**: `cd ./web && npm i && npm run start-ui-test`

Edit: We won't test with Netlify, because that is for actual app testing :)