### PR TITLE
Move platform toggler in front of filter widgets

### DIFF
--- a/web/src/ui/components/Filters.js
+++ b/web/src/ui/components/Filters.js
@@ -196,9 +196,6 @@ const Filters = () => {
 
   return (
     <div className="filter-wrapper--yl">
-      {FiltersAppWidget()}
-      {FiltersPlatformWidget()}
-      {FiltersBranchWidget()}
       <div className="filter-select--yl">
         <select
           disabled={!state.isLoaded}
@@ -222,6 +219,9 @@ const Filters = () => {
           <option value={PLATFORMS.android}>Android</option>
         </select>
       </div>
+      {FiltersAppWidget()}
+      {FiltersPlatformWidget()}
+      {FiltersBranchWidget()}
     </div>
   );
 };


### PR DESCRIPTION
Just switch the position of functional platform toggler in front of display widgets, so that mobile users can access it.

Preview: 
![image](https://user-images.githubusercontent.com/24300177/79876457-5b44a500-83eb-11ea-8c51-856949d95bce.png)


It will soon be replaced by the filters modal.