### PR TITLE
Feat(web): Add filter modal

### DIFF
--- a/web/src/assets/main.scss
+++ b/web/src/assets/main.scss
@@ -2,7 +2,7 @@
 
 // global tabler css overrides
 
-.btn,
+.btn:not([class^='btn-outline']):not([class*=' btn-outline']),
 .card .btn,
 .btn.btn-primary:not([class^='btn-outline']):not([class*=' btn-outline']):not([class^='btn-ghost']):not([class*=' btn-ghost']):not(:focus):not(.focus),
 .btn.btn-primary:not([class^='btn-outline']):not([class*=' btn-outline']):not([class^='btn-ghost']):not([class*=' btn-ghost']):not(.btn-secondary) {

--- a/web/src/store/ResultStore.js
+++ b/web/src/store/ResultStore.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useContext, useReducer, createContext} from 'react';
 import {cloneDeep} from 'lodash';
 
 // TODO: Yes, this file needs a new name, and should maybe be split
@@ -11,19 +11,19 @@ export const PLATFORMS = {
 };
 
 const INITIAL_STATE = {
-  platformId: '3',
+  platformId: PLATFORMS.iOS,
   apiKey: `${process.env.YOLO_APP_PW || ''}`,
   error: null,
-  isLoaded: true,
+  isLoaded: false,
   items: [],
   baseURL: `${process.env.API_SERVER}`,
   filtersPlatform: {
-    iOS: false,
+    iOS: true,
     android: false,
   },
   filtersBranch: {
-    master: true,
-    develop: true,
+    master: false,
+    develop: false,
     all: true,
   },
   filtersApp: {
@@ -31,13 +31,26 @@ const INITIAL_STATE = {
     mini: false,
     maxi: false,
   },
+  filtersImplemented: {
+    apps: ['chat'],
+    os: ['iOS'],
+    branch: ['all'],
+  },
 };
 
+function _reducer(state, action) {
+  switch (action.type) {
+    case 'updateState':
+      return {...state, ...action.payload};
+    default:
+      throw new Error(); // TODO: Handle me
+  }
+}
+
 export const ResultStore = ({children}) => {
-  const [state, setState] = useState({...INITIAL_STATE});
+  const [state, dispatch] = useReducer(_reducer, INITIAL_STATE);
   const updateState = (newState) => {
-    const combinedState = cloneDeep({...state, ...newState});
-    return setState(combinedState);
+    return dispatch({type: 'updateState', payload: cloneDeep(newState)});
   };
 
   return (

--- a/web/src/styleTools/themes.js
+++ b/web/src/styleTools/themes.js
@@ -8,7 +8,7 @@ export const themes = {
       tagGreen: '#d3f8f2',
       tagPink: '#fee4e9',
       tagOrange: '#fff0d4',
-      btnPrimary: '3f49ea',
+      btnPrimary: '#3f49ea',
       btnDlMaster: '#36D1AE',
       btnDlPull: '#8877d8',
       filter: '#f0f1ff',

--- a/web/src/ui/components/FilterModal.js
+++ b/web/src/ui/components/FilterModal.js
@@ -1,0 +1,237 @@
+import React, {useContext, useState} from 'react';
+import {ThemeContext} from '../../store/ThemeStore';
+import {Check, GitBranch, GitMerge, GitCommit, X} from 'react-feather';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faAndroid, faApple} from '@fortawesome/free-brands-svg-icons';
+import {faQuestionCircle} from '@fortawesome/free-solid-svg-icons';
+import IconChat from '../../assets/svg/IconChat';
+import IconMini from '../../assets/svg/IconMini';
+import classNames from 'classnames';
+import {ResultContext} from '../../store/ResultStore';
+import './FilterModal.scss';
+
+const FilterModal = ({clickAction}) => {
+  const {theme} = useContext(ThemeContext);
+  const {state, updatestate} = useContext(ResultContext);
+  const [selectedProjects] = useState(['chat']);
+  const [selectedOs] = useState(['iOS']);
+  const [selectedBranches] = useState(['all']);
+  const filterSelectedAccent = theme.icon.filterSelected;
+
+  const applyFilterButtonColors = {
+    backgroundColor: theme.bg.btnPrimary,
+    border: '1px solid ' + theme.bg.btnPrimary,
+    boxShadow: '0px 4px 0px ' + theme.shadow.btnPrimary,
+  };
+
+  const colorsCloseButton = {
+    backgroundColor: theme.bg.filter,
+  };
+
+  const colorsModal = {
+    backgroundColor: theme.bg.page,
+    color: theme.text.sectionText,
+  };
+
+  const colorsModalTitle = {
+    color: theme.text.sectionTitle,
+  };
+
+  const colorsWidget = ({selected} = {selected: false}) => {
+    const {
+      text: {filterSelectedTitle, filterUnselectedTitle},
+      bg: {filter: bgFilter},
+      border: {
+        filterSelected: selectedBorder,
+        filterUnselected: unselectedBorder,
+      },
+    } = theme;
+    return selected
+      ? {
+          color: filterSelectedTitle,
+          borderColor: selectedBorder,
+          backgroundColor: bgFilter,
+        }
+      : {
+          color: filterUnselectedTitle,
+          borderColor: unselectedBorder,
+          background: 'transparent',
+        };
+  };
+
+  const colorsIcon = ({selected} = {selected: false}) => {
+    return selected ? theme.icon.filterSelected : theme.icon.filterUnselected;
+  };
+  const ProjectFilter = ({name}) => {
+    const selected = selectedProjects.includes(name);
+    const implemented = state.filtersImplemented.apps.includes(name);
+    const colorIcon = colorsIcon({selected});
+    const colorWidget = colorsWidget({selected});
+    const widgetClass = classNames('modal-filter-widget--yl', {
+      'filter-not-implemented': !implemented,
+    });
+    const icon =
+      name === 'chat' ? (
+        <IconChat stroke={colorIcon} />
+      ) : name === 'mini' ? (
+        <IconMini stroke={colorIcon} />
+      ) : (
+        <React.Fragment />
+      );
+    const projectName =
+      name === 'chat'
+        ? 'Berty Chat'
+        : name === 'mini'
+        ? 'Berty Mini'
+        : 'Berty Maxi';
+    return (
+      <div className={widgetClass} style={colorWidget}>
+        {icon}
+        <p className="filter-text--yl">{projectName}</p>
+      </div>
+    );
+  };
+
+  const OsFilter = ({name}) => {
+    const selected = selectedOs.includes(name);
+    const implemented = state.filtersImplemented.os.includes(name);
+    const colorIcon = colorsIcon({selected});
+    const colorWidget = colorsWidget({selected});
+    const widgetClass = classNames('modal-filter-widget--yl', {
+      'filter-not-implemented': !implemented,
+    });
+    const icon =
+      name === 'iOS' ? (
+        <FontAwesomeIcon icon={faApple} size="lg" color={colorIcon} />
+      ) : name === 'android' ? (
+        <FontAwesomeIcon icon={faAndroid} size="lg" color={colorIcon} />
+      ) : name === 'macOS' ? (
+        <FontAwesomeIcon icon={faApple} size="lg" color={colorIcon} />
+      ) : (
+        <FontAwesomeIcon icon={faQuestionCircle} size="lg" color={colorIcon} />
+      );
+    const osName =
+      name === 'iOS'
+        ? 'iOS'
+        : name === 'android'
+        ? 'Android'
+        : name === 'macOS'
+        ? 'Mac OS'
+        : '?';
+    return (
+      <div className={widgetClass} style={colorWidget}>
+        {icon}
+        <p className="filter-text--yl">{osName}</p>
+      </div>
+    );
+  };
+
+  const BranchFilter = ({name}) => {
+    const selected = selectedBranches.includes(name);
+    const implemented = state.filtersImplemented.branch.includes(name);
+    const colorIcon = colorsIcon({selected});
+    const colorWidget = colorsWidget({selected});
+    const widgetClass = classNames('modal-filter-widget--yl', {
+      'filter-not-implemented': !implemented,
+    });
+    const icon =
+      name === 'all' ? (
+        <GitBranch color={colorIcon} />
+      ) : name === 'master' ? (
+        <GitCommit color={colorIcon} />
+      ) : name === 'develop' ? (
+        <GitMerge color={colorIcon} />
+      ) : (
+        <React.Fragment />
+      );
+    const branchName =
+      name === 'all'
+        ? 'All'
+        : name === 'master'
+        ? 'Master'
+        : name === 'develop'
+        ? 'Development'
+        : '?';
+    return (
+      <div className={widgetClass} style={colorWidget}>
+        {icon}
+        <p className="filter-text--yl">{branchName}</p>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <div className="faded" />
+      <div
+        className="modal modal-blur fade show"
+        id="modal-large"
+        tabIndex="-1"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div
+          className="modal-dialog modal-lg modal-dialog-centered"
+          role="document"
+        >
+          <div className="modal-content" style={colorsModal}>
+            <div className="modal-header">
+              <h5 className="modal-title" style={colorsModalTitle}>
+                Filter the builds
+              </h5>
+              <div
+                className="btn-close--yl"
+                data-dismiss="modal"
+                aria-label="Close"
+                onClick={clickAction}
+                style={colorsCloseButton}
+              >
+                <X size={14} strokeWidth={3} color={filterSelectedAccent} />
+              </div>
+            </div>
+            <div className="modal-body">
+              <div style={colorsModalTitle} className="subtitle--yl">
+                Projects
+              </div>
+              <div className="filter-row--yl">
+                {ProjectFilter({name: 'chat'})}
+                {ProjectFilter({name: 'mini'})}
+                {ProjectFilter({name: 'maxi'})}
+              </div>
+              <div style={colorsModalTitle} className="subtitle--yl">
+                OS
+              </div>
+              <div className="filter-row--yl">
+                {OsFilter({name: 'iOS'})}
+                {OsFilter({name: 'android'})}
+                {OsFilter({name: 'macOS'})}
+              </div>
+              <div style={colorsModalTitle} className="subtitle--yl">
+                Branches
+              </div>
+              <div className="filter-row--yl">
+                {BranchFilter({name: 'all'})}
+                {BranchFilter({name: 'master'})}
+                {BranchFilter({name: 'develop'})}
+              </div>
+            </div>
+            <div className="modal-footer">
+              <div
+                type="button"
+                className="btn-primary--yl"
+                data-dismiss="modal"
+                onClick={clickAction}
+                style={applyFilterButtonColors}
+              >
+                <Check />
+                <div className="btn-text--yl">Apply Filters</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FilterModal;

--- a/web/src/ui/components/FilterModal.scss
+++ b/web/src/ui/components/FilterModal.scss
@@ -1,0 +1,105 @@
+// tabler overrides
+
+#modal-simple {
+  padding-right: 15px;
+  display: block;
+}
+
+.modal.modal-blur.fade.show {
+  padding-right: 15px;
+  display: block;
+  top: auto;
+  bottom: 0.75em;
+  left: 0;
+  right: 0;
+}
+
+.modal-dialog .modal-content {
+  border-radius: 15px;
+  border: none;
+  padding: 15px;
+}
+
+.modal-content .modal-header {
+  border-bottom: none;
+}
+
+.modal-content .modal-footer {
+  border-top: none;
+  justify-content: center;
+}
+
+.modal-title {
+  font-size: larger;
+}
+
+.btn-close--yl {
+  display: flex;
+  justify-content: center;
+  padding: 0.3em;
+  border-radius: 50%;
+}
+
+// custom classes
+
+.faded {
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  z-index: 1049;
+  background-color: black;
+  opacity: 0.4;
+}
+
+// TODO: Hover, active, etc
+.btn-primary--yl {
+  padding: 8px 14px 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 6px;
+  display: flex;
+  justify-content: center;
+  color: white;
+  cursor: pointer;
+  div {
+    margin-left: 0.5em;
+  }
+}
+
+.modal-filter-widget--yl {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 15px;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 15px;
+  margin-right: 0.75em;
+  width: auto;
+  cursor: default; // no filters are interactive right now
+  //   cursor: pointer; // right now there are no filters to toggle
+  div {
+    flex: 0 0 auto;
+  }
+  &.filter-not-implemented {
+    border-style: dotted;
+    cursor: default;
+  }
+}
+
+.subtitle--yl {
+  font-size: small;
+  margin-bottom: 0.5em;
+}
+
+.filter-row--yl {
+  display: flex;
+  margin-bottom: 1.5em;
+}
+
+p.filter-text--yl {
+  font-size: 0.7em;
+  padding: 0px;
+  margin: 0px;
+}

--- a/web/src/ui/components/Header/Header.js
+++ b/web/src/ui/components/Header/Header.js
@@ -7,16 +7,18 @@ import ActionWidgets from '../ActionWidgets';
 import ThemeToggler from '../ThemeToggler';
 import {User} from 'react-feather';
 import './Header.scss';
+import {ResultContext} from '../../../store/ResultStore';
 
 const Header = () => {
   const {theme} = useContext(ThemeContext);
+  const {state, updateState} = useContext(ResultContext);
 
   // TODO: Dynamic, based on device etc
   const yoloLogo = 'yoloLogo';
 
   return (
     <div
-      className={'header--yl pt-2 mb-2 px-md-4 pb-0 mt-2'}
+      className={'header--yl pt-2 mb-5 px-md-4 pb-0 mt-2'}
       style={{backgroundColor: theme.bg.page}}
     >
       <div className={yoloLogo}>
@@ -24,6 +26,18 @@ const Header = () => {
       </div>
       <ActionWidgets>
         <Filters />
+        <div
+          className="btn btn-outline-info btn-sm"
+          onClick={() =>
+            updateState({
+              isLoaded: false,
+              items: [],
+              platformId: state.platformId,
+            })
+          }
+        >
+          F5
+        </div>
       </ActionWidgets>
       <ThemeToggler />
       <div className="headerUser">

--- a/web/src/ui/components/ShowFiltersButton.js
+++ b/web/src/ui/components/ShowFiltersButton.js
@@ -1,0 +1,30 @@
+import React, {useContext} from 'react';
+import {ThemeContext} from '../../store/ThemeStore';
+import {Sliders} from 'react-feather';
+
+const ShowFiltersButton = ({clickAction, showingFiltersModal}) => {
+  const {theme} = useContext(ThemeContext);
+
+  const notShowingFiltersStyle = {
+    position: 'fixed',
+    right: '1em',
+    bottom: '1em',
+    borderRadius: '50%',
+    padding: '0.8em',
+    margin: '12px',
+    backgroundColor: theme.bg.btnPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    transform: 'rotate(90deg)',
+    cursor: 'pointer',
+    display: showingFiltersModal ? 'none' : 'flex',
+  };
+
+  return (
+    <div style={notShowingFiltersStyle} onClick={clickAction}>
+      <Sliders color="white" />
+    </div>
+  );
+};
+
+export default ShowFiltersButton;

--- a/web/src/ui/components/ThemeToggler.js
+++ b/web/src/ui/components/ThemeToggler.js
@@ -18,9 +18,18 @@ const ThemeToggler = () => {
     if (isDark) changeTheme('dark');
   }, []);
 
+  const buttonStyle = {
+    display: 'flex',
+    flex: '1 0 auto',
+    justifyContent: 'flex-end',
+    marginRight: '80px',
+    fontSize: '2rem',
+    cursor: 'pointer',
+  };
+
   return (
     <div
-      className="btn btn-primary btn-sm"
+      style={buttonStyle}
       onClick={() => {
         return changeTheme(theme.name === 'light' ? 'dark' : 'light');
       }}

--- a/web/src/ui/pages/Home/Home.js
+++ b/web/src/ui/pages/Home/Home.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-named-as-default */
-import React, {useContext} from 'react';
+import React, {useContext, useState} from 'react';
 import {ThemeContext} from '../../../store/ThemeStore';
 import './Home.scss';
 import Header from '../../components/Header/Header';
@@ -8,10 +8,13 @@ import ErrorDisplay from '../../components/ErrorDisplay';
 import BuildList from '../../components/BuildList';
 import ApiKeyPrompt from '../../components/ApiKeyPrompt';
 import {cloneDeep} from 'lodash';
+import ShowFiltersButton from '../../components/ShowFiltersButton';
+import FilterModal from '../../components/FilterModal';
 
 const Home = () => {
   const {theme} = useContext(ThemeContext);
   const {state, updateState} = useContext(ResultContext);
+  const [showingFiltersModal, toggleShowFilters] = useState(false);
 
   return (
     <div className={'app--app-container'}>
@@ -29,6 +32,24 @@ const Home = () => {
           style={{backgroundColor: theme.bg.block}}
         ></div>
       </div>
+      {!showingFiltersModal && (
+        <ShowFiltersButton
+          showingFiltersModal={showingFiltersModal}
+          clickAction={() => toggleShowFilters(!showingFiltersModal)}
+        />
+      )}
+      {showingFiltersModal && (
+        <FilterModal
+          clickAction={() => {
+            updateState({
+              isLoaded: false,
+              items: [],
+              platformId: state.platformId,
+            });
+            toggleShowFilters(!showingFiltersModal);
+          }}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Feat(web): Add filter modal

**tl;dr adds a modal to select filters (but it's not interactive yet, since we don't have multiple filters available right now)**

UX changes:
* Adds filter modal display button (bottom left)
* Adds filter modal on click of this button
* F5/refresh button added to header
* Style theme toggler
* Removes dropdown platform selector (only the iOS platform artifacts are available anyway)

Functionality changes:
* List of iOS builds is pulled by default

Refactoring:
* Add basis for using reducer instead of useState hook in global store
* Refresh capability: Setting `isLoaded` in store to false will trigger a new call to server

**To test**: Make sure it's looking good in the netlify preview and on your mobile device!

Header: (RED == temporary)
![Screenshot 2020-04-22 at 16 59 58](https://user-images.githubusercontent.com/24300177/79998321-d628c100-84ba-11ea-9977-eb59d66025bb.png)

Filter modal:
![image](https://user-images.githubusercontent.com/24300177/79998489-0cfed700-84bb-11ea-8b8e-374ff826ac6f.png)


Related to #12 #62 