### PR TITLE
Refactor(front): Pass reducer in global context provider

### DIFF
--- a/web/src/constants/actions.js
+++ b/web/src/constants/actions.js
@@ -1,0 +1,1 @@
+export const UPDATE_STATE = 'updateState';

--- a/web/src/constants/index.js
+++ b/web/src/constants/index.js
@@ -1,3 +1,5 @@
+import * as actions from './actions.js';
+
 export const KIND_TO_PLATFORM = {
   IPA: 'iOS',
   APK: 'Android',
@@ -10,3 +12,5 @@ export const PLATFORMS = {
   android: '2',
   none: '3',
 };
+
+export {actions};

--- a/web/src/store/ResultStore.js
+++ b/web/src/store/ResultStore.js
@@ -1,7 +1,7 @@
 import React, {useReducer} from 'react';
 import {cloneDeep} from 'lodash';
-import {PLATFORMS} from '../constants';
 import {retrieveAuthCookie} from '../api/auth';
+import {actions, PLATFORMS} from '../constants';
 
 // TODO: Yes, this file needs a new name, and should maybe be split
 export const ResultContext = React.createContext();
@@ -37,7 +37,7 @@ export const INITIAL_STATE = {
 
 function _reducer(state, action) {
   switch (action.type) {
-    case 'updateState':
+    case actions.UPDATE_STATE:
       return {...state, ...action.payload};
     default:
       return {...state};
@@ -46,12 +46,15 @@ function _reducer(state, action) {
 
 export const ResultStore = ({children}) => {
   const [state, dispatch] = useReducer(_reducer, INITIAL_STATE);
-  const updateState = (newState) => {
-    return dispatch({type: 'updateState', payload: cloneDeep(newState)});
+
+  // custom actions can go here; for now we just have one
+  const updateState = (payload) => {
+    dispatch({type: actions.UPDATE_STATE, payload: cloneDeep(payload)});
   };
 
+  // pass dispatch if we want to trigger an action without an action creator
   return (
-    <ResultContext.Provider value={{state, updateState}}>
+    <ResultContext.Provider value={{state, dispatch, updateState}}>
       {children}
     </ResultContext.Provider>
   );


### PR DESCRIPTION
We need this to be able to handle complicated actions sanely (e.g. routing, API param changes, etc.)

Blocked by #121 (note to self, this isn't a magic keyword as I thought)