### PR TITLE
Add MR Title with PR id and Build ID fallbacks to card title

### DIFF
--- a/web/src/ui/components/BuildCard/ArtifactCard.js
+++ b/web/src/ui/components/BuildCard/ArtifactCard.js
@@ -18,7 +18,7 @@ import './BuildCard.scss';
 const ArtifactCard = ({
   artifact,
   buildMergeUpdatedAt,
-  buildMergeId,
+  mrShortId,
   startedAt,
   finishedAt,
 }) => {
@@ -60,7 +60,7 @@ const ArtifactCard = ({
       : '';
   const timeSinceBuildUpdatedString = `updated: ${buildMergeUpdatedAt}`;
   const ArtifactKindName = KIND_TO_PLATFORM[artifactKind] || 'Unknown OS';
-  const BuildMergeId = buildMergeId || '';
+  const MrShortId = mrShortId || '';
 
   const artifactTagStyle = tagStyle({name: theme.name, stateNormed});
   const artifactActionButtonStyle = actionButtonStyle({
@@ -147,7 +147,7 @@ const ArtifactCard = ({
         <div className="card-details">
           <div className="card-details-row">
             <div className="">
-              {ArtifactKindName} {BuildMergeId}
+              {ArtifactKindName} {MrShortId}
             </div>
             {ArtifactStateTag}
           </div>

--- a/web/src/ui/components/BuildCard/BuildCard.js
+++ b/web/src/ui/components/BuildCard/BuildCard.js
@@ -27,10 +27,11 @@ const BuildCard = ({item}) => {
     started_at: startedAt = '',
     finished_at: finishedAt = '',
     has_mergerequest: {
-      short_id: buildMrId = '',
+      short_id: mrShortId = '',
       commit_url: commitUrl = '',
       updated_at: buildMergeUpdatedAt = '',
-      id: buildMergeIdUrl = '',
+      id: mrId = '',
+      title: mrTitle = '',
       has_author: {
         name: buildAuthorName = '',
         id: buildAuthorId,
@@ -39,10 +40,10 @@ const BuildCard = ({item}) => {
     } = {},
     has_project: {id: buildProjectUrl = ''} = {},
   } = item || {};
-  const stateNormed = buildState.toUpperCase();
+  const buildStateNormed = buildState.toUpperCase();
+  const buildBranchNormed = buildBranch.toUpperCase();
 
-  const [buildMergeId] = buildMergeIdUrl.match(/\d+?$/) || [];
-  const buildTagStyle = tagStyle({name: theme.name, stateNormed});
+  const buildTagStyle = tagStyle({name: theme.name, buildStateNormed});
   const COMMIT_LEN = 7;
   const MESSAGE_LEN = 280;
 
@@ -56,9 +57,15 @@ const BuildCard = ({item}) => {
 
   const CardTitle = (
     <div className="card-title">
-      {`${
-        buildBranch.toUpperCase() === 'MASTER' ? 'Master' : 'Pull'
-      } ${buildMrId}`}
+      {mrTitle
+        ? mrTitle
+        : `${
+            mrShortId
+              ? 'Pull: ' + mrShortId
+              : buildShortId
+              ? 'Build: ' + buildShortId
+              : ''
+          }`}
     </div>
   );
 
@@ -245,7 +252,8 @@ const BuildCard = ({item}) => {
             <ArtifactCard
               artifact={artifact}
               buildMergeUpdatedAt={buildMergeUpdatedAt}
-              buildMergeId={buildMergeId}
+              mrId={mrId}
+              mrShortId={mrShortId}
               startedAt={startedAt}
               finishedAt={finishedAt}
               key={artifact.id}


### PR DESCRIPTION
Related to #71 

Card title:

1. MR title if available
2. `Pull: <MR short ID>`
3. `Build: <build short ID>`
4. Blank

Note: Option of title `Master` is removed, so a merge on Master with no MR will have title `Build: <build short ID>`