### PR TITLE
Feat(web): Collapse cards if any branch in results is master

### DIFF
--- a/web/src/api/dataTransforms.js
+++ b/web/src/api/dataTransforms.js
@@ -14,8 +14,7 @@ export const queryHasMaster = {
       : true,
   toCollapse: (build) => {
     return (
-      (build && !build.branch) ||
-      (build && build.branch && build.branch.toUpperCase() !== BRANCH.MASTER)
+      build && build.branch && build.branch.toUpperCase() !== BRANCH.MASTER
     );
   },
 };

--- a/web/src/ui/components/BuildList.js
+++ b/web/src/ui/components/BuildList.js
@@ -17,11 +17,11 @@ const BuildList = ({loaded, builds, collapseCondition}) => {
         <BuildCard
           key={'item.id' + i}
           build={build}
-          // toCollapse={
-          //   useCollapseCondition && collapseCondition.toCollapse(build)
-          //     ? true
-          //     : false
-          // }
+          toCollapse={
+            useCollapseCondition && collapseCondition.toCollapse(build)
+              ? true
+              : false
+          }
         />
       ))}
     </div>


### PR DESCRIPTION
- refactor: items --> builds
- Add collapse condition function
- Collapse cards if master branch is present in query results

**Asking for review; 2 questions:**
1. Is this really the intended behaviour (do we want to hide collapse ALL build details if ANY master branch build is present, or only collapse branch details if it shares a build short ID with a Master build short ID)?
2. Bintray builds and others with no `build.branch` or `build.has_mergerequest.branch` - collapse or no?

Closes #168 