### PR TITLE
Fix: Keep MR message as subtitle in buildcards

### DIFF
--- a/web/src/ui/components/BuildCard/BuildCard.js
+++ b/web/src/ui/components/BuildCard/BuildCard.js
@@ -57,15 +57,17 @@ const BuildCard = ({build, toCollapse}) => {
 
   const CardTitle = (
     <div className="card-title">
-      {mrTitle
-        ? mrTitle
-        : `${
-            mrShortId
-              ? 'Pull: ' + mrShortId
-              : buildShortId
-              ? 'Build: ' + buildShortId
-              : ''
-          }`}
+      <div className="short-card-title">
+        {mrShortId
+          ? 'Pull ' + mrShortId
+          : buildShortId
+          ? (buildBranchNormed === 'MASTER' ? 'Master ' : 'Build ') +
+            buildShortId
+          : ''}
+      </div>
+      <div className="card-mr-subtitle" style={colorPlainText}>
+        {mrTitle ? mrTitle : ''}
+      </div>
     </div>
   );
 

--- a/web/src/ui/components/BuildCard/BuildCard.scss
+++ b/web/src/ui/components/BuildCard/BuildCard.scss
@@ -65,11 +65,37 @@
   }
 
   .card div.card-row .card-title {
-    height: 100%;
     padding: 0px;
     margin: 0px;
     flex: 0 1 auto;
     margin-right: auto;
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    @include lg {
+      flex-wrap: nowrap;
+      white-space: unset;
+    }
+    .short-card-title {
+      flex: 1 1 100%;
+      white-space: nowrap;
+      @include lg {
+        flex: 1 1 auto;
+        white-space: unset;
+      }
+    }
+    .card-mr-subtitle {
+      font-size: 0.9rem;
+      margin-top: 0.2rem;
+      margin-left: 0px;
+      flex: 0 1 100%;
+      @include lg {
+        font-size: 1.125rem;
+        flex: 0 1 auto;
+        margin-top: 0px;
+        margin-left: 8px;
+      }
+    }
   }
 
   .card div.card-row .card-author {


### PR DESCRIPTION
Small screens:

![image](https://user-images.githubusercontent.com/24300177/80998435-42a0aa00-8e43-11ea-91d6-f30532d0ee16.png)

Large screens:

![image](https://user-images.githubusercontent.com/24300177/80998472-4fbd9900-8e43-11ea-864c-2761ff0b8d0d.png)

Also changes `Build <BuildId>` to `Master <BuildId>` if there is a build branch called Master (these do not have MR short Id's as far as I can tell.)

Closes #173 
