### PR TITLE
test(front): update fetch stub

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "start-message": "babel-node tools/startMessage.js",
     "prestart": "npm run start-message",
     "start": "npm run open:src",
-    "start-ui-test": "env YOLO_UI_TEST=true npm run open:src",
+    "start-ui-test": "env YOLO_UI_TEST=true env MOCK_DATA_FILE_ENDPOINT=${MOCK_DATA_FILE_ENDPOINT} npm run open:src",
     "open:src": "babel-node tools/srcServer.js",
     "open:dist": "babel-node tools/distServer.js",
     "lint": "esw webpack.config.* src tools --color",

--- a/web/src/api/mock.js
+++ b/web/src/api/mock.js
@@ -1,16 +1,13 @@
-import queryString from 'query-string';
+import axios from 'axios';
 
-const mockResponse = process.env.MOCK_DATA_PATH
-  ? process.env.MOCK_DATA_PATH['JSON']
-  : null;
-
+/**
+ * Serve a JSON document here
+ * e.g. process.env.MOCK_DATA_FILE_ENDPOINT = 'localhost:8000/data.json'
+ * { "JSON": { "builds": [...]}}
+ */
 export const baseMockRequest = ({queryObject = {}, locationQuery = ''}) =>
-  Promise.resolve(mockResponse).then(async (response) => {
-    // Uncomment to check search params
-    // const formattedParams = queryString.stringify({
-    //   ...queryObject,
-    //   ...locationQuery,
-    // });
-    await new Promise((r) => setTimeout(r, 2000));
-    return await response;
+  axios.get(`${process.env.MOCK_DATA_FILE_ENDPOINT}`).then((response) => {
+    const result = response.data.JSON;
+    const {builds} = result;
+    return {data: {builds}};
   });


### PR DESCRIPTION
Uses axios to fetch a defined static file served over HTTP, as I often want to test the UI with custom cases.

Setting `MOCK_DATA_FILE_ENDPOINT` will allow axios to read this file if `npm run start-ui-test` is run from ./web directory.