### PR TITLE
feat(front): add anchor links to builds and artifacts

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4123,6 +4123,14 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "copy-webpack-plugin": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
@@ -12988,6 +12996,15 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-copy-to-clipboard": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.2.tgz",
+      "integrity": "sha512-/2t5mLMMPuN5GmdXo6TebFa8IoFxZ+KTDDqYhcDm0PhkgEzSxVvIX26G20s1EB02A4h2UZgwtfymZ3lGJm0OLg==",
+      "requires": {
+        "copy-to-clipboard": "^3",
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -15462,6 +15479,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,7 @@
     "dayjs": "^1.8.25",
     "js-cookie": "^2.2.1",
     "react": "16.13.1",
+    "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "16.13.1",
     "react-feather": "2.0.3",
     "react-hook-form": "5.2.0",

--- a/web/src/constants/index.js
+++ b/web/src/constants/index.js
@@ -32,12 +32,6 @@ export const ARTIFACT_KINDS = Object.values(ARTIFACT_KIND_VALUE).map((kind) =>
   kind.toString()
 );
 
-export const PLATFORMS = {
-  iOS: '1',
-  android: '2',
-  none: '3',
-};
-
 export const BRANCH = {
   MASTER: 'MASTER',
 };

--- a/web/src/store/ResultStore.js
+++ b/web/src/store/ResultStore.js
@@ -1,7 +1,7 @@
 import React, {useReducer} from 'react';
 import {cloneDeep} from 'lodash';
 import {retrieveAuthCookie} from '../api/auth';
-import {actions, PLATFORMS, ARTIFACT_KIND_VALUE} from '../constants';
+import {actions, ARTIFACT_KIND_VALUE} from '../constants';
 
 // TODO: Yes, this file needs a new name, and should maybe be split
 export const ResultContext = React.createContext();
@@ -18,10 +18,6 @@ export const INITIAL_STATE = {
   uiFilters: {
     artifact_kinds: [ARTIFACT_KIND_VALUE.IPA],
   },
-  filtersPlatform: {
-    iOS: true,
-    android: false,
-  },
   filtersBranch: {
     master: false,
     develop: false,
@@ -33,7 +29,6 @@ export const INITIAL_STATE = {
   },
   filtersImplemented: {
     apps: ['chat'],
-    os: ['iOS', 'android'],
     branch: ['all'],
   },
 };

--- a/web/src/ui/components/AnchorLink.js
+++ b/web/src/ui/components/AnchorLink.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import {CopyToClipboard} from 'react-copy-to-clipboard';
+
+const AnchorLink = ({
+  tooltipMessage,
+  setTooltipMessage,
+  location,
+  children,
+  target,
+}) => {
+  return (
+    <>
+      <div className="copy-artifact-to-clipboard-icon">
+        {tooltipMessage && (
+          <div className="badge badge-secondary confirm-copy">
+            {tooltipMessage}
+          </div>
+        )}
+        <CopyToClipboard
+          text={`${window.location.protocol}//${window.location.host}${location.pathname}${location.search}#${target}`}
+          title="Copy link to clipboard"
+          onCopy={() => {
+            setTooltipMessage('Link copied');
+            setTimeout(() => setTooltipMessage(''), 1000);
+          }}
+        >
+          {children}
+        </CopyToClipboard>
+      </div>
+    </>
+  );
+};
+
+export default AnchorLink;

--- a/web/src/ui/components/BuildCard/ArtifactCard.js
+++ b/web/src/ui/components/BuildCard/ArtifactCard.js
@@ -1,6 +1,12 @@
-import React, {useContext} from 'react';
+import React, {useContext, useState, useRef, useEffect} from 'react';
 import {ThemeContext} from '../../../store/ThemeStore';
-import {Clock, Calendar, ArrowDownCircle, AlertTriangle} from 'react-feather';
+import {
+  Clock,
+  Calendar,
+  ArrowDownCircle,
+  AlertTriangle,
+  Link,
+} from 'react-feather';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faAndroid, faApple} from '@fortawesome/free-brands-svg-icons';
 import {
@@ -8,13 +14,18 @@ import {
   faFile,
   faHammer,
 } from '@fortawesome/free-solid-svg-icons';
+import {useLocation} from 'react-router-dom';
 
 import {tagStyle, actionButtonStyle} from '../../styleTools/buttonStyler';
+import AnchorLink from '../AnchorLink';
 
 import {KIND_TO_PLATFORM, ARTIFACT_STATE} from '../../../constants';
 import {getTimeDuration, getRelativeTime} from '../../../util/date';
 
 import './BuildCard.scss';
+
+// TODO: Factor out into DOM util file
+const scrollToRef = (ref) => window.scrollTo(0, ref.current.offsetTop);
 
 const ArtifactCard = ({
   artifact,
@@ -22,8 +33,10 @@ const ArtifactCard = ({
   mrShortId,
   buildStartedAt,
   buildFinishedAt,
+  hashLinkMatch,
 }) => {
   const {theme} = useContext(ThemeContext);
+  const location = useLocation();
   const {
     id: artifactId = '',
     state: artifactState = '',
@@ -34,6 +47,15 @@ const ArtifactCard = ({
     file_size: artifactFileSize = '',
     driver: artifactDriver = '',
   } = artifact;
+  const [tooltipMessage, setTooltipMessage] = useState('');
+  const artifactRef = useRef(null);
+
+  const executeScroll = () => scrollToRef(artifactRef);
+  useEffect(() => {
+    if (hashLinkMatch === true) {
+      executeScroll();
+    }
+  }, []);
 
   const timeSinceBuildUpdated = getRelativeTime(buildMergeUpdatedAt);
   const buildDurationSeconds = getTimeDuration(buildStartedAt, buildFinishedAt);
@@ -148,13 +170,30 @@ const ArtifactCard = ({
     </div>
   );
 
+  const SharableArtifactLink = (
+    <AnchorLink
+      theme={theme}
+      color={theme.text.sectionText}
+      tooltipMessage={tooltipMessage}
+      setTooltipMessage={setTooltipMessage}
+      location={location}
+      children={<Link size={16} />}
+      target={artifactId}
+    />
+  );
+
   return (
     <React.Fragment key={artifactId}>
       <div
+        id={artifactId}
         className="card-row expanded"
         style={{color: theme.text.sectionText}}
+        ref={artifactRef}
       >
-        <div className="card-left-icon icon-top">{PlatformIcon}</div>
+        <div className="card-left-icon icon-top">
+          {SharableArtifactLink}
+          {PlatformIcon}
+        </div>
         <div className="card-details">
           <div className="card-details-row">
             <div className="">

--- a/web/src/ui/components/BuildCard/BuildCard.scss
+++ b/web/src/ui/components/BuildCard/BuildCard.scss
@@ -23,6 +23,14 @@
     }
   }
 
+  div.confirm-copy {
+    position: absolute;
+    width: auto;
+    white-space: nowrap;
+    opacity: 0.9;
+    padding: 0.2rem;
+  }
+
   pre {
     padding: 0px;
     margin: 0px;
@@ -34,6 +42,29 @@
   div.card {
     max-width: 100vw;
     min-width: 0;
+  }
+
+  .copy-build-to-clipboard-icon {
+    display: none;
+    @include xs {
+      display: block;
+      position: absolute;
+      top: 0.5rem;
+      left: 0.5rem;
+      cursor: pointer;
+    }
+  }
+
+  .copy-artifact-to-clipboard-icon {
+    display: none;
+    @include xs {
+      display: block;
+      position: absolute;
+      left: 0.5rem;
+      //   top: 0.5rem;
+      //   left: 0.5rem;
+      cursor: pointer;
+    }
   }
 
   .card div.card-row {

--- a/web/src/ui/components/BuildList.js
+++ b/web/src/ui/components/BuildList.js
@@ -15,7 +15,7 @@ const BuildList = ({loaded, builds, collapseCondition}) => {
     <div className="container">
       {builds.map((build, i) => (
         <BuildCard
-          key={'item.id' + i}
+          key={`${build.id}-${i}`}
           build={build}
           toCollapse={
             useCollapseCondition && collapseCondition.toCollapse(build)

--- a/web/src/ui/components/FilterModal/FilterModal.js
+++ b/web/src/ui/components/FilterModal/FilterModal.js
@@ -10,7 +10,6 @@ import classNames from 'classnames';
 import {ResultContext} from '../../../store/ResultStore';
 import './FilterModal.scss';
 import {
-  PLATFORMS,
   ARTIFACT_KIND_TO_PLATFORM,
   ARTIFACT_KIND_VALUE,
   ARTIFACT_KINDS,
@@ -27,11 +26,6 @@ const FilterModal = ({closeAction, showingFiltersModal}) => {
   ]);
   const [selectedBranches] = useState(['all']);
   const filterSelectedAccent = theme.icon.filterSelected;
-
-  const updateLocalOs = ({name}) => {
-    setSelectedOs([name]);
-    setLocalPlatformId(PLATFORMS[name]);
-  };
 
   const applyFilterButtonColors = {
     backgroundColor: theme.bg.btnPrimary,

--- a/web/src/ui/components/ShowFiltersButton.js
+++ b/web/src/ui/components/ShowFiltersButton.js
@@ -23,7 +23,7 @@ const ShowFiltersButton = ({clickAction, showingFiltersModal}) => {
 
   return (
     <div style={showFiltersButtonStyle} onClick={clickAction}>
-      <Sliders color="white" size="1.3rem" />
+      <Sliders color="white" size={20} />
     </div>
   );
 };

--- a/web/src/ui/pages/Home/Home.js
+++ b/web/src/ui/pages/Home/Home.js
@@ -16,7 +16,7 @@ import MessageModal from '../../components/MessageModal/MessageModal';
 import {ThemeContext} from '../../../store/ThemeStore';
 import {ResultContext} from '../../../store/ResultStore';
 
-import {PLATFORMS, ARTIFACT_KINDS} from '../../../constants';
+import {ARTIFACT_KINDS} from '../../../constants';
 import {getBuildList, validateError} from '../../../api';
 
 import './Home.scss';


### PR DESCRIPTION
Normally there is now an anchor link available next to each build card header and individual artifacts; copies to clipboard on click.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/24300177/81581282-cf50e800-93ae-11ea-8276-c3f093c58263.png">

Closes #180 