### PR TITLE
fix(front): make protocol warning button look interactive

### DIFF
--- a/web/src/ui/components/MessageModal/MessageModal.js
+++ b/web/src/ui/components/MessageModal/MessageModal.js
@@ -26,7 +26,7 @@ const MessageModal = ({closeAction}) => {
               <div className="modal-footer">
                 <button
                   type="button"
-                  className="btn btn-ghost-dark"
+                  className="btn btn-sm btn-shadow"
                   data-dismiss="modal"
                   onClick={closeAction}
                 >

--- a/web/src/ui/components/MessageModal/MessageModal.scss
+++ b/web/src/ui/components/MessageModal/MessageModal.scss
@@ -33,7 +33,15 @@
     flex-basis: 100%;
   }
 
-  .btn.btn-ghost-dark {
+  button.btn.btn-sm.btn-shadow {
     background-color: transparent;
+    border-width: 1px;
+    border-radius: 15%;
+    border-color: darken(#f7d68e, 20%);
+    box-shadow: 0px 0.25rem 0px darken(#f7d68e, 30%);
+    border-style: solid;
+    &:hover {
+      background-color: darken(#f7d68e, 10%);
+    }
   }
 }


### PR DESCRIPTION
Add shadow to button (same style as green download button in Artifact list), darken background on hover

(Preview on hover:)
<img width="530" alt="image" src="https://user-images.githubusercontent.com/24300177/81598658-f49e2000-93c7-11ea-8337-83972c5dd670.png">

Closes #203 