### PR TITLE
feat(front): allow filtering from ui by project

### DIFF
--- a/web/src/constants/index.js
+++ b/web/src/constants/index.js
@@ -32,9 +32,52 @@ export const ARTIFACT_KINDS = Object.values(ARTIFACT_KIND_VALUE).map((kind) =>
   kind.toString()
 );
 
+export const PROJECT = {
+  chat: 'chat',
+  'gomobile-ipfs-demo': 'gomobile-ipfs-demo',
+};
+
+export const PROJECTS = Object.values(PROJECT);
+
+export const BUILD_DRIVER_VALUE = {
+  UnknownDriver: '0',
+  Buildkite: '1',
+  CircleCI: '2',
+  Bintray: '3',
+  GitHub: '4',
+};
+
+export const BUILD_DRIVER_TO_NAME = {
+  '0': 'UnknownDriver',
+  '1': 'Buildkite',
+  '2': 'CircleCI',
+  '3': 'Bintray',
+  '4': 'GitHub',
+};
+
+export const BUILD_DRIVERS = Object.values(BUILD_DRIVER_VALUE);
+
+export const PROJECT_BUILD_DRIVER = {
+  chat: BUILD_DRIVER_VALUE.Buildkite,
+  'gomobile-ipfs-demo': BUILD_DRIVER_VALUE.Bintray,
+};
+
+export const PROJECT_ARTIFACT_KINDS = {
+  chat: [ARTIFACT_KIND_VALUE.IPA],
+  'gomobile-ipfs-demo': [ARTIFACT_KIND_VALUE.APK, ARTIFACT_KIND_VALUE.IPA],
+};
+
 export const BRANCH = {
   MASTER: 'MASTER',
 };
+
+export const BRANCH_TO_DISPLAY_NAME = {
+  MASTER: 'Master',
+  DEVELOP: 'Development',
+  ALL: 'All',
+};
+
+export const IMPLEMENTED_BRANCHES = ['ALL'];
 
 export const MR_STATE = {
   UnknownState: 'UnknownState',

--- a/web/src/store/ResultStore.js
+++ b/web/src/store/ResultStore.js
@@ -1,8 +1,13 @@
 import React, {useReducer} from 'react';
 import {cloneDeep} from 'lodash';
 import {retrieveAuthCookie} from '../api/auth';
-import {actions, ARTIFACT_KIND_VALUE} from '../constants';
 import {groupBuildsByMr} from '../api/dataTransforms';
+import {
+  actions,
+  ARTIFACT_KIND_VALUE,
+  PROJECT,
+  PROJECT_BUILD_DRIVER,
+} from '../constants';
 
 // TODO: Yes, this file needs a new name, and should maybe be split
 export const ResultContext = React.createContext();
@@ -19,19 +24,10 @@ export const INITIAL_STATE = {
   needsRefresh: false,
   uiFilters: {
     artifact_kinds: [ARTIFACT_KIND_VALUE.IPA],
+    build_driver: [PROJECT_BUILD_DRIVER[PROJECT.chat]],
   },
-  filtersBranch: {
-    master: false,
-    develop: false,
-    all: true,
-  },
-  filtersApp: {
-    chat: true,
-    mini: false,
-  },
-  filtersImplemented: {
-    apps: ['chat'],
-    branch: ['all'],
+  calculatedFilters: {
+    projects: [PROJECT.chat],
   },
 };
 

--- a/web/src/ui/components/FilterModal/FilterModal.scss
+++ b/web/src/ui/components/FilterModal/FilterModal.scss
@@ -72,6 +72,10 @@
       border-style: dotted;
       cursor: default;
     }
+    &.not-interactive {
+      opacity: 0.4;
+      cursor: default;
+    }
   }
 
   .subtitle {

--- a/web/src/ui/components/Filters/Filters.js
+++ b/web/src/ui/components/Filters/Filters.js
@@ -1,18 +1,21 @@
 import React, {useContext} from 'react';
-import {GitMerge, GitBranch, GitCommit, LogOut} from 'react-feather';
+import {GitBranch, LogOut} from 'react-feather';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faAndroid, faApple} from '@fortawesome/free-brands-svg-icons';
-import {faQuestionCircle} from '@fortawesome/free-solid-svg-icons';
+import {faQuestionCircle, faCube} from '@fortawesome/free-solid-svg-icons';
 
 import {ResultContext} from '../../../store/ResultStore.js';
 import {ThemeContext} from '../../../store/ThemeStore.js';
 
 import IconChat from '../../../assets/svg/IconChat';
-import IconMini from '../../../assets/svg/IconMini';
 
 import './Filters.scss';
 import {removeAuthCookie} from '../../../api/auth';
-import {ARTIFACT_KIND_VALUE, ARTIFACT_VALUE_KIND} from '../../../constants';
+import {
+  ARTIFACT_KIND_VALUE,
+  ARTIFACT_VALUE_KIND,
+  PROJECT,
+} from '../../../constants';
 
 const Filters = () => {
   const {state, updateState} = useContext(ResultContext);
@@ -25,110 +28,69 @@ const Filters = () => {
     backgroundColor: theme.bg.filter,
   };
 
-  const shouldRenderUiFilter = ({key = artifact_kinds}) =>
-    state.uiFilters[key] &&
-    Array.isArray(state.uiFilters[key]) &&
-    state.uiFilters[key].length > 0;
-
-  // TODO: Unecessary abstraction
-  const HeaderWidgetWrapper = ({children}) => (
-    <div className="widget-wrapper" style={headerWidgetWrapperColors}>
-      {children}
-    </div>
-  );
-
-  // TODO: Unecessary abstraction
-  const HeaderWidget = ({children, text}) => {
-    return (
-      <React.Fragment>
-        {children}
-        {text && <p className="widget-text">{text}</p>}
-      </React.Fragment>
-    );
-  };
+  const isArrayWithStuff = (val) =>
+    !!val && Array.isArray(val) && val.length > 0;
 
   const FiltersAppWidget = () => {
-    const {
-      filtersApp: {chat, mini},
-    } = state;
     return (
       <React.Fragment>
-        {chat && (
-          <HeaderWidgetWrapper
-            children={
-              <HeaderWidget
-                text="Chat"
-                children={<IconChat stroke={widgetAccentColor} />}
+        {isArrayWithStuff(state.calculatedFilters.projects) &&
+          state.calculatedFilters.projects.includes(PROJECT.chat) && (
+            <div className="widget-wrapper" style={headerWidgetWrapperColors}>
+              <IconChat stroke={widgetAccentColor} />
+              <p className="widget-text">{PROJECT.chat}</p>
+            </div>
+          )}
+        {isArrayWithStuff(state.calculatedFilters.projects) &&
+          state.calculatedFilters.projects.includes(
+            PROJECT['gomobile-ipfs-demo']
+          ) && (
+            <div className="widget-wrapper" style={headerWidgetWrapperColors}>
+              <FontAwesomeIcon
+                icon={faCube}
+                size={'lg'}
+                color={widgetAccentColor}
               />
-            }
-          />
-        )}
-        {mini && (
-          <HeaderWidgetWrapper
-            children={
-              <HeaderWidget
-                text="Mini"
-                children={<IconMini stroke={widgetAccentColor} />}
-              />
-            }
-          />
-        )}
+              <p className="widget-text">{PROJECT['gomobile-ipfs-demo']}</p>
+            </div>
+          )}
       </React.Fragment>
     );
   };
 
-  const ArtifactKindsFilter = () =>
-    shouldRenderUiFilter({key: 'artifact_kinds'}) && (
-      <div className="widget-wrapper" style={headerWidgetWrapperColors}>
-        {state.uiFilters.artifact_kinds.map((kind, i) => (
-          <FontAwesomeIcon
-            key={i}
-            size="lg"
-            color={widgetAccentColor}
-            icon={
-              kind == ARTIFACT_KIND_VALUE.IPA ||
-              kind === ARTIFACT_KIND_VALUE.DMG
-                ? faApple
-                : kind === ARTIFACT_KIND_VALUE.APK
-                ? faAndroid
-                : faQuestionCircle
-            }
-            title={ARTIFACT_VALUE_KIND[kind.toString()] || ''}
-          />
-        ))}
-      </div>
+  const ArtifactKindsFilter = () => {
+    return (
+      isArrayWithStuff(state.uiFilters.artifact_kinds) && (
+        <div className="widget-wrapper" style={headerWidgetWrapperColors}>
+          {state.uiFilters.artifact_kinds.map((kind, i) => (
+            <FontAwesomeIcon
+              key={i}
+              size="lg"
+              color={widgetAccentColor}
+              icon={
+                kind == ARTIFACT_KIND_VALUE.IPA ||
+                kind === ARTIFACT_KIND_VALUE.DMG
+                  ? faApple
+                  : kind === ARTIFACT_KIND_VALUE.APK
+                  ? faAndroid
+                  : faQuestionCircle
+              }
+              title={ARTIFACT_VALUE_KIND[kind.toString()] || ''}
+            />
+          ))}
+        </div>
+      )
     );
+  };
 
   const FiltersBranchWidget = () => {
-    const {
-      filtersBranch: {master, develop, all},
-    } = state;
-    let branchWidget;
-    if (all) {
-      branchWidget = (
-        <HeaderWidget
-          text="All"
-          children={<GitBranch color={widgetAccentColor} />}
-        />
-      );
-    } else if (master) {
-      branchWidget = (
-        <HeaderWidget
-          text="Master"
-          children={<GitCommit color={widgetAccentColor} />}
-        />
-      );
-    } else if (develop) {
-      branchWidget = (
-        <HeaderWidget
-          text="Develop"
-          children={<GitMerge color={widgetAccentColor} />}
-        />
-      );
-    } else {
-      branchWidget = <React.Fragment />;
-    }
-    return <HeaderWidgetWrapper children={branchWidget} />;
+    const BranchFilter = <GitBranch color={widgetAccentColor} />;
+    return (
+      <div className="widget-wrapper" style={headerWidgetWrapperColors}>
+        {BranchFilter}
+        <p className="widget-text">All</p>
+      </div>
+    );
   };
 
   const RefreshActionButton = (

--- a/web/src/ui/pages/Home/Home.js
+++ b/web/src/ui/pages/Home/Home.js
@@ -16,7 +16,7 @@ import MessageModal from '../../components/MessageModal/MessageModal';
 import {ThemeContext} from '../../../store/ThemeStore';
 import {ResultContext} from '../../../store/ResultStore';
 
-import {ARTIFACT_KINDS} from '../../../constants';
+import {ARTIFACT_KINDS, BUILD_DRIVERS} from '../../../constants';
 import {getBuildList, validateError} from '../../../api';
 
 import './Home.scss';
@@ -41,22 +41,32 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
+    console.log(' --- Home first render');
     if (!locationSearch) {
       history.push({
         pathname: '/',
         search: queryString.stringify({
           artifact_kinds: [state.uiFilters.artifact_kinds],
+          build_driver: [state.uiFilters.build_driver],
         }),
       });
     } else {
       const locationObject = queryString.parse(locationSearch);
-      const {artifact_kinds: kindsInQuery = []} = locationObject;
+      const {
+        artifact_kinds: kindsInQuery = [],
+        build_driver: buildDriversInQuery = [],
+      } = locationObject;
       const artifact_kinds = (!Array.isArray(kindsInQuery)
         ? [kindsInQuery]
         : kindsInQuery
       ).filter((kind) => ARTIFACT_KINDS.includes(kind));
+      const build_driver = (!Array.isArray(buildDriversInQuery)
+        ? [buildDriversInQuery]
+        : buildDriversInQuery
+      ).filter((bd) => BUILD_DRIVERS.includes(bd));
+
       updateState({
-        uiFilters: {artifact_kinds},
+        uiFilters: {...state.uiFilters, artifact_kinds, build_driver},
       });
     }
   }, []);
@@ -108,7 +118,7 @@ const Home = () => {
       });
       history.push({
         path: '/',
-        search: queryString.stringify(state.uiFilters),
+        search: queryString.stringify(state.uiFilters) || `limit=50`,
       });
       setNeedsNewFetch(true);
     };


### PR DESCRIPTION
TODO:
- [x] bug: handle no driver or artifact kind is in global state filters
- [x] decide if having an 'all' option for apps and artifact kinds is necessary (decided no for this MR)
- [x] more manual tests, might finally need to implement error boundary (#72 )

* allow filtering by project OR artifact kinds from filter modal
* add gomobile-ipfs-demo (is there a shorter name for this?) to UI
* filter by project gomobile-ipfs-demo triggers query `?artifact_kinds=2&artifact_kinds=1&build_driver=3`
* filter by project chat triggers query `?artifact_kinds=1&build_driver=1`

Style tweaks:
* add style for disabled filters in modal

Blocks #202 
Closes #201 