### PR TITLE
feat(front): add sharable links to builds and artifacts in feed

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -84,6 +84,7 @@
         ]
       }
     ],
+    "jsx-a11y/anchor-is-valid": 0,
     "class-methods-use-this": 0,
     "react/jsx-filename-extension": 0,
     "react/forbid-prop-types": 0,

--- a/web/src/ui/components/AnchorLink.js
+++ b/web/src/ui/components/AnchorLink.js
@@ -1,25 +1,21 @@
 import React from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 
-/**
- * TODO: Not currently used; use it for routes, not page locations
- */
 const AnchorLink = ({
   tooltipMessage,
   setTooltipMessage,
-  location,
   children,
   target,
 }) => (
   <>
-    <div className="copy-artifact-to-clipboard-icon">
+    <div className="copy-link-icon">
       {tooltipMessage && (
       <div className="badge badge-secondary confirm-copy">
         {tooltipMessage}
       </div>
       )}
       <CopyToClipboard
-        text={`${window.location.protocol}//${window.location.host}${location.pathname}${location.search}#${target}`}
+        text={`${window.location.protocol}//${window.location.host}${location.pathname}${target}`}
         title="Copy link to clipboard"
         onCopy={() => {
           setTooltipMessage('Link copied')

--- a/web/src/ui/components/Build/ArtifactCard.js
+++ b/web/src/ui/components/Build/ArtifactCard.js
@@ -6,7 +6,7 @@ import {
   Calendar,
   ArrowDownCircle,
   AlertTriangle,
-  Link,
+  Link as LinkIcon,
 } from 'react-feather'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAndroid, faApple } from '@fortawesome/free-brands-svg-icons'
@@ -23,6 +23,7 @@ import { KIND_TO_PLATFORM, ARTIFACT_STATE } from '../../../constants'
 import { getTimeDuration, getRelativeTime } from '../../../util/date'
 
 import './Build.scss'
+import AnchorLink from '../AnchorLink'
 
 const ArtifactCard = ({
   artifact,
@@ -32,6 +33,9 @@ const ArtifactCard = ({
   buildShortId,
 }) => {
   const { theme } = useContext(ThemeContext)
+
+  // TODO: Factor out, duplicated in Build
+  const [tooltipMessage, setTooltipMessage] = useState('')
   const {
     id: artifactId = '',
     state: artifactState = '',
@@ -156,6 +160,16 @@ const ArtifactCard = ({
     </div>
   )
 
+  const SharableArtifactLink = (
+    <AnchorLink
+      tooltipMessage={tooltipMessage}
+      setTooltipMessage={setTooltipMessage}
+      target={`?artifact_id=${artifactId}`}
+    >
+      <LinkIcon size={16} />
+    </AnchorLink>
+  )
+
   return (
     <React.Fragment key={artifactId}>
       <div
@@ -163,7 +177,10 @@ const ArtifactCard = ({
         className="card-row expanded"
         style={{ color: theme.text.sectionText }}
       >
-        <div className="card-left-icon icon-top">{PlatformIcon}</div>
+        <div className="card-left-icon icon-top">
+          {PlatformIcon}
+          {/* {SharableArtifactLink} TODO: Add when API working for this */}
+        </div>
         <div className="card-details">
           <div className="card-details-row">
             <div className="">

--- a/web/src/ui/components/Build/Build.scss
+++ b/web/src/ui/components/Build/Build.scss
@@ -47,25 +47,11 @@
         border-radius: 0.33rem;
     }
 
-    .copy-build-to-clipboard-icon {
+    .copy-link-icon {
         display: none;
         @include xs {
             display: block;
-            position: absolute;
-            top: 0.5rem;
-            left: 0.5rem;
-            cursor: pointer;
-        }
-    }
-
-    .copy-artifact-to-clipboard-icon {
-        display: none;
-        @include xs {
-            display: block;
-            position: absolute;
-            left: 0.5rem;
-            //   top: 0.5rem;
-            //   left: 0.5rem;
+            margin-top: 0.5rem;
             cursor: pointer;
         }
     }
@@ -75,7 +61,6 @@
         margin: 0px;
         padding: 0.5rem;
         width: 100%;
-        align-items: center;
         height: 100%;
         margin-bottom: 0.3rem;
         &:first-child {
@@ -105,9 +90,6 @@
             &.icon-top {
                 align-self: flex-start;
                 margin-bottom: 0.5rem;
-            }
-            &.rotate-merge {
-                transform: rotate(90deg);
             }
         }
     }

--- a/web/src/ui/components/Build/BuildAndMergeRequest.js
+++ b/web/src/ui/components/Build/BuildAndMergeRequest.js
@@ -2,7 +2,7 @@ import React, {
   useContext, useState, useRef, useEffect,
 } from 'react'
 import {
-  GitCommit, GitPullRequest, AlertCircle, Calendar,
+  GitCommit, GitPullRequest, AlertCircle, Calendar, Link as LinkIcon,
 } from 'react-feather'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
@@ -12,6 +12,7 @@ import {
   faPencilAlt,
   faFile,
 } from '@fortawesome/free-solid-svg-icons'
+import classNames from 'classnames'
 
 import { ThemeContext } from '../../../store/ThemeStore'
 
@@ -22,9 +23,11 @@ import { MR_STATE, BUILD_STATE } from '../../../constants'
 import { getRelativeTime, getTimeLabel } from '../../../util/date'
 
 import './Build.scss'
+import AnchorLink from '../AnchorLink'
 
 const BuildAndMergeRequest = ({ build, mr, isDetailed }) => {
   const [messageExpanded, toggleMessageExpanded] = useState(true)
+  const [tooltipMessage, setTooltipMessage] = useState('')
 
   const {
     theme,
@@ -73,22 +76,18 @@ const BuildAndMergeRequest = ({ build, mr, isDetailed }) => {
     color: sectionText,
   }
 
+  const iconLeftClass = (rotate = false) => classNames('card-left-icon', 'icon-top', { 'rotate-merge': !!rotate })
+
   const CommitIcon = mrCommitUrl ? (
     <a
       href={mrCommitUrl}
-      className="card-left-icon icon-top"
-      title={buildCommitId || ''}
     >
-      <GitCommit color={blockTitle} />
+      <GitCommit color={blockTitle} title={buildCommitId || ''} />
     </a>
   ) : !buildHasMr ? (
-    <div className="card-left-icon icon-top rotate-merge">
-      <GitCommit color={sectionText} />
-    </div>
+    <GitCommit color={sectionText} style={{ transform: 'rotate(90deg)' }} />
   ) : (
-    <div className="card-left-icon icon-top" title={buildCommitId || ''}>
-      <GitCommit color={sectionText} />
-    </div>
+    <GitCommit color={sectionText} title={buildCommitId || ''} />
   )
 
   const SplitMessage = (text) => text
@@ -245,10 +244,23 @@ const BuildAndMergeRequest = ({ build, mr, isDetailed }) => {
     </div>
   )
 
+  const SharableBuildLink = (
+    <AnchorLink
+      tooltipMessage={tooltipMessage}
+      setTooltipMessage={setTooltipMessage}
+      target={`?build_id=${buildId}`}
+    >
+      <LinkIcon size={16} />
+    </AnchorLink>
+  )
+
   return (
     <>
       <div className="card-row expanded" style={{ color: sectionText }}>
-        {CommitIcon}
+        <div className="card-left-icon icon-top">
+          {CommitIcon}
+          {SharableBuildLink}
+        </div>
         <div className="card-details">
           {isDetailed && (buildCommitId || mrState || mrDriver) && (
             <div className="card-details-row">
@@ -265,7 +277,7 @@ const BuildAndMergeRequest = ({ build, mr, isDetailed }) => {
             <div className="card-details-row">{BuildMessage}</div>
           )}
 
-          <div className="card-details-row">
+          <div className="card-details-row" style={{ alignSelf: 'flex-start' }}>
             {!isDetailed && <div>{`Build ${buildShortId || buildId}`}</div>}
             {BuildState}
             {BuildDriver}


### PR DESCRIPTION
- add anchor link to artifacts
- add anchor link to builds (commented out until API is working)

Unlike old version (#205 ) this one simply copies the URL (not target link) of yolo URL w/ search params corresponding to artifact/link.