### PR TITLE
refactor(front): memoize build grouping and split out build components

### DIFF
--- a/web/src/store/ResultStore.js
+++ b/web/src/store/ResultStore.js
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react'
+import React, { useReducer, useMemo } from 'react'
 import { cloneDeep } from 'lodash'
 import { retrieveAuthCookie } from '../api/auth'
 import { groupBuildsByMr } from '../api/dataTransforms'
@@ -18,7 +18,6 @@ export const INITIAL_STATE = {
   error: null,
   isLoaded: false,
   builds: [],
-  buildsByMr: [],
   baseURL: `${process.env.API_SERVER}`,
   needsProgrammaticQuery: false,
   needsRefresh: false,
@@ -42,22 +41,22 @@ function reducer(state, action) {
 
 export const ResultStore = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+  const buildsByMr = useMemo(() => groupBuildsByMr(state.builds), [
+    state.builds,
+  ])
 
   // custom actions can go here; for now we just have one
   const updateState = (payload) => {
     dispatch({ type: actions.UPDATE_STATE, payload: cloneDeep(payload) })
-    if (payload.builds?.length) {
-      const groupedData = groupBuildsByMr(payload.builds)
-      dispatch({
-        type: actions.UPDATE_STATE,
-        payload: { buildsByMr: groupedData },
-      })
-    }
   }
 
   // pass dispatch if we want to trigger an action without an action creator
   return (
-    <ResultContext.Provider value={{ state, dispatch, updateState }}>
+    <ResultContext.Provider
+      value={{
+        state, dispatch, buildsByMr, updateState,
+      }}
+    >
       {children}
     </ResultContext.Provider>
   )

--- a/web/src/ui/components/BuildList.js
+++ b/web/src/ui/components/BuildList.js
@@ -1,34 +1,23 @@
-import React, { useContext } from 'react'
-
-import { ThemeContext } from '../../store/ThemeStore'
-import { ResultContext } from '../../store/ResultStore'
+import React from 'react'
 import BuildContainer from './Build/BuildContainer'
 
-const BuildList = ({ loaded, builds, collapseCondition }) => {
-  const { theme } = useContext(ThemeContext)
-  const { state } = useContext(ResultContext)
-  const loading = <div style={{ color: theme.text.sectionText }}>Loading...</div>
+const BuildList = ({ buildsByMr, builds = [], collapseCondition }) => {
   const useCollapseCondition = collapseCondition.condition(builds)
-  return (
-    <>
-      {!loaded ? (
-        loading
-      ) : !builds.length ? (
-        <div>No results match your query.</div>
-      ) : (
-        <div className="container">
-          {state.buildsByMr.map((build, i) => (
-            <BuildContainer
-              key={`${build.id}-${i}`}
-              build={build}
-              toCollapse={
-                !!(useCollapseCondition && collapseCondition.toCollapse(build))
-              }
-            />
-          ))}
-        </div>
-      )}
-    </>
+  const NoBuilds = () => <div>No results match your query.</div>
+  return !builds.length ? (
+    <NoBuilds />
+  ) : (
+    <div className="container">
+      {buildsByMr.map((build, i) => (
+        <BuildContainer
+          key={`${build.id}-${i}`}
+          build={build}
+          toCollapse={
+            !!(useCollapseCondition && collapseCondition.toCollapse(build))
+          }
+        />
+      ))}
+    </div>
   )
 }
 

--- a/web/src/ui/components/BuildListContainer.js
+++ b/web/src/ui/components/BuildListContainer.js
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react'
+
+import { ThemeContext } from '../../store/ThemeStore'
+import BuildList from './BuildList'
+import { ResultContext } from '../../store/ResultStore'
+
+const BuildListContainer = ({ loaded, builds, collapseCondition }) => {
+  const { theme } = useContext(ThemeContext)
+  const { buildsByMr } = useContext(ResultContext)
+  const Loading = () => (
+    <div style={{ color: theme.text.sectionText }}>Loading...</div>
+  )
+  return (
+    <>
+      {!loaded ? (
+        <Loading />
+      ) : (
+        <BuildList
+          builds={builds}
+          buildsByMr={buildsByMr}
+          collapseCondition={collapseCondition}
+        />
+      )}
+    </>
+  )
+}
+
+export default BuildListContainer

--- a/web/src/ui/pages/Home/Home.js
+++ b/web/src/ui/pages/Home/Home.js
@@ -1,13 +1,11 @@
 /* eslint-disable import/no-named-as-default */
 import React, { useContext, useState, useEffect } from 'react'
 import { useLocation, useHistory } from 'react-router-dom'
-import { cloneDeep } from 'lodash'
 import queryString from 'query-string'
 import Cookies from 'js-cookie'
 
 import Header from '../../components/Header/Header'
 import ErrorDisplay from '../../components/ErrorDisplay/ErrorDisplay'
-import BuildList from '../../components/BuildList'
 import ApiKeyPrompt from '../../components/ApiKeyPrompt'
 import ShowFiltersButton from '../../components/ShowFiltersButton'
 import FilterModal from '../../components/FilterModal/FilterModal'
@@ -21,6 +19,7 @@ import { getBuildList, validateError } from '../../../api'
 
 import './Home.scss'
 import { queryHasMaster } from '../../../api/dataTransforms'
+import BuildListContainer from '../../components/BuildListContainer'
 
 const Home = () => {
   const { theme } = useContext(ThemeContext)
@@ -153,8 +152,8 @@ const Home = () => {
           <ApiKeyPrompt failedKey={state.apiKey} updateState={updateState} />
         )}
         {!state.error && (
-          <BuildList
-            builds={cloneDeep(state.builds)}
+          <BuildListContainer
+            builds={state.builds}
             loaded={state.isLoaded}
             collapseCondition={queryHasMaster}
           />


### PR DESCRIPTION
- Make frontend calculation of build groups happen in memoizing callback (in order to reduce prop drilling and unnecessary global state modification)
- Split BuildList --> BuildListContainer + BuildList
- Style Loading and NoBuilds as sub-components

Blocks #209 