### PR TITLE
feat(front): show running build count in collapsed blocks

### DIFF
--- a/web/src/api/dataGetters.js
+++ b/web/src/api/dataGetters.js
@@ -1,6 +1,14 @@
-import { getStrUpperCase } from '../util/getters'
-import { BRANCH } from '../constants'
+import { getStrUpperCase, getIsArrayWithN, getIsArray } from '../util/getters'
+import { BRANCH, BUILD_STATE } from '../constants'
 
-export const buildBranchIsMaster = (build) => getStrUpperCase(build.branch) === BRANCH.MASTER
+export const buildBranchIsMaster = (build) => (getStrUpperCase(build.branch) === BRANCH.MASTER)
 
-export const oneBuildResultHasBranchMaster = (builds) => !!Array.isArray(builds) && builds.find((build) => buildBranchIsMaster(build))
+export const oneBuildResultHasBranchMaster = (builds) => (getIsArray(builds) && builds.find((build) => buildBranchIsMaster(build)))
+
+export const buildStateIsRunning = (build) => (build && build.state && build.state.toString() === BUILD_STATE.Running.toString())
+
+export const buildsStateIsRunning = (allBuildsForMr, originalBuildList) => getIsArray(allBuildsForMr) && getIsArrayWithN(originalBuildList)
+  ? allBuildsForMr
+    .filter((buildIndex) => (typeof buildIndex === 'number' && !!originalBuildList[buildIndex]))
+    .filter((buildIndex) => (buildStateIsRunning(originalBuildList[buildIndex])))
+  : []

--- a/web/src/api/dataTransforms.js
+++ b/web/src/api/dataTransforms.js
@@ -27,7 +27,7 @@ export const flagBuildsFirstOfDay = (sortedTopLevelBuilds) => Array.isArray(sort
  * Returns a new copy of builds[],
  * keeping only the first build from each unique merge request.
  *
- * Adds entry {allBuilds: Array<int>} to each build,
+ * Adds entry {allBuildsForMr: Array<int>} to each build,
  * each int corresponds to builds indices in state.builds
  *   with the same merge request ID
  *
@@ -48,21 +48,21 @@ export const groupBuildsByMr = (builds) => {
           ...acc,
           [build.id]: {
             ...build,
-            allBuilds: [i],
+            allBuildsForMr: [i],
           },
         }
       }
 
       const matchingBuild = acc[buildMrId] || null
       if (matchingBuild) {
-        if (!matchingBuild.allBuilds) {
-          acc[buildMrId].allBuilds = [i]
+        if (!matchingBuild.allBuildsForMr) {
+          acc[buildMrId].allBuildsForMr = [i]
         } else {
-          acc[buildMrId].allBuilds = [...matchingBuild.allBuilds, i]
+          acc[buildMrId].allBuildsForMr = [...matchingBuild.allBuildsForMr, i]
         }
       } else {
         acc[buildMrId] = { ...build }
-        acc[buildMrId].allBuilds = [i]
+        acc[buildMrId].allBuildsForMr = [i]
       }
       return acc
     }, {})

--- a/web/src/ui/components/Build/BuildAndMrContainer.js
+++ b/web/src/ui/components/Build/BuildAndMrContainer.js
@@ -23,16 +23,22 @@ import Tag from '../Tag/Tag'
 
 import { MR_STATE, BUILD_STATE } from '../../../constants'
 import { getRelativeTime, getTimeLabel } from '../../../util/date'
-import { getIsArr } from '../../../util/getters'
+import { getIsArray } from '../../../util/getters'
 
 import './Build.scss'
 import ShownBuildsButton from '../ShownBuildsButton'
 
 const BuildAndMrContainer = ({
-  build, buildHasMr, isLatestBuild, nOlderBuilds, showingAllBuilds, toggleShowingAllBuilds,
+  build,
+  buildHasMr,
+  isLatestBuild,
+  nOlderBuilds,
+  showingAllBuilds,
+  toggleShowingAllBuilds,
+  hasRunningBuilds,
 }) => {
   const [messageExpanded, toggleMessageExpanded] = useState(false)
-  const showingArtifacts = isLatestBuild || showingAllBuilds
+  const showingArtifacts = isLatestBuild || showingAllBuilds || hasRunningBuilds
 
   const {
     theme,
@@ -299,7 +305,7 @@ const BuildAndMrContainer = ({
       </div>
       {/* TODO: Condition to show artifacts of older builds */}
       {showingArtifacts
-        && getIsArr(buildHasArtifacts)
+        && getIsArray(buildHasArtifacts)
         && buildHasArtifacts.map((artifact) => (
           <ArtifactRow
             artifact={artifact}

--- a/web/src/ui/components/Build/BuildBlockHeader.js
+++ b/web/src/ui/components/Build/BuildBlockHeader.js
@@ -56,6 +56,7 @@ const BuildBlockHeader = ({
       <div className={blockRowClassNames}>
         <BlockIcon />
         {blockTitle}
+
         <Author
           authorName={buildAuthorName || undefined}
           authorUrl={buildAuthorId}

--- a/web/src/ui/components/BuildList.js
+++ b/web/src/ui/components/BuildList.js
@@ -3,6 +3,7 @@ import BuildContainer from './Build/BuildContainer'
 import {
   oneBuildResultHasBranchMaster,
   buildBranchIsMaster,
+  buildsStateIsRunning,
 } from '../../api/dataGetters'
 import {
   groupBuildsByMr,
@@ -12,24 +13,27 @@ import Divider from './Divider'
 import { getDayFormat } from '../../util/date'
 
 const BuildList = ({ builds = [] }) => {
-  const useCollapseCondition = oneBuildResultHasBranchMaster(builds)
+  const oneBuildInResultsHasMaster = oneBuildResultHasBranchMaster(builds)
   const buildsByMr = groupBuildsByMr(builds)
-  const buildsFlaggedWithFirstDay = flagBuildsFirstOfDay(buildsByMr)
+
+  const buildsByMrWithDateFlag = flagBuildsFirstOfDay(buildsByMr)
   const NoBuilds = () => <div>No results match your query.</div>
 
   return !builds.length ? (
     <NoBuilds />
   ) : (
     <div className="container">
-      {buildsFlaggedWithFirstDay.map((build, i) => (
+      {buildsByMrWithDateFlag.map((build, i) => (
         <BuildContainer
           key={`${build.id}-${i}`}
           build={build}
-          toCollapse={useCollapseCondition && !buildBranchIsMaster(build)}
+          toCollapse={oneBuildInResultsHasMaster && !buildBranchIsMaster(build)}
+          hasRunningBuilds={buildsStateIsRunning(build.allBuildsForMr, builds)}
         >
           {build.buildIsFirstOfDay && (
-            <Divider dividerText={getDayFormat(build.created_at)} />
+          <Divider dividerText={getDayFormat(build.created_at)} />
           )}
+
         </BuildContainer>
       ))}
     </div>

--- a/web/src/util/getters.js
+++ b/web/src/util/getters.js
@@ -6,14 +6,14 @@ export const getStrEquNormalized = (str1, str2) => (getStrUpperCase(str1)
   && getStrUpperCase(str2)
   && getStrUpperCase(str1) === getStrUpperCase(str2))
 
-export const getIsArr = (val) => (val && Array.isArray(val))
+export const getIsArray = (val) => (val && Array.isArray(val))
 
-export const getIsArrayWithN = (val, n) => (getIsArr(val) && val.length >= n)
+export const getIsArrayWithN = (val, n = 1) => (getIsArray(val) && val.length >= n)
 
-export const getIsEmptyArr = (val) => (getIsArr(val) && val.length === 0)
+export const getIsEmptyArr = (val) => (getIsArray(val) && val.length === 0)
 
 const getIsObject = (val) => (val && typeof val === 'object')
 
-export const getIsEmpty = (val) => (!val || (getIsArr(val) && !val.length) || (getIsObject(val) && !Object.keys(val).length))
+export const getIsEmpty = (val) => (!val || (getIsArray(val) && !val.length) || (getIsObject(val) && !Object.keys(val).length))
 
-export const singleItemToArray = (val) => !Array.isArray(val) ? [val] : val
+export const singleItemToArray = (val) => !getIsArray(val) ? [val] : val


### PR DESCRIPTION
- show X Builds Running on collapsed build block (if it is a block grouped by MR, with N builds > 1 and at least one build in grouped block having build.state === Running)

![image](https://user-images.githubusercontent.com/24300177/82681358-f381b400-9c4d-11ea-89d2-27b2ba16976c.png)

Relates to #144 
