### PR TITLE
feat(front): build block header icons correspond to MR status

### DIFF
--- a/web/src/ui/components/Build/ArtifactRow.js
+++ b/web/src/ui/components/Build/ArtifactRow.js
@@ -1,22 +1,18 @@
-import React, { useContext, useState } from 'react'
-import { Clock, Calendar, Link as LinkIcon } from 'react-feather'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFile, faHammer, faQrcode } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import QRCode from 'qrcode.react'
-
-import { ThemeContext } from '../../../store/ThemeStore'
-
-import { tagStyle } from '../../styleTools/buttonStyler'
-import { getArtifactKindIcon } from '../../styleTools/brandIcons'
-
+import React, { useContext, useState } from 'react'
+import { Calendar, Clock, Link as LinkIcon } from 'react-feather'
 import { KIND_TO_PLATFORM } from '../../../constants'
-import { getTimeDuration, getRelativeTime } from '../../../util/date'
-
-import './Build.scss'
+import { ThemeContext } from '../../../store/ThemeStore'
+import { getRelativeTime, getTimeDuration } from '../../../util/date'
+import { getArtifactKindIcon } from '../../styleTools/brandIcons'
 import AnchorLink from '../AnchorLink/AnchorLink'
+import QRCodeModal from '../QRCodeModal'
 import Tag from '../Tag/Tag'
 import ArtifactActionButton from './ArtifactActionButton'
-import QRCodeModal from '../QRCodeModal'
+import './Build.scss'
+
 
 const ArtifactRow = ({
   artifact,
@@ -52,14 +48,14 @@ const ArtifactRow = ({
 
   const ArtifactKindName = () => <div>{KIND_TO_PLATFORM[artifactKind] || 'Unknown OS'}</div>
 
-  const artifactTagStyle = tagStyle({ name: theme.name, state: artifactState })
-  const ArtifactStateTag = () => artifactState && (
-    <Tag
-      classes={['artifact-tag', 'state-tag']}
-      styles={artifactTagStyle}
-      text={artifactState}
-    />
-  )
+  // const artifactTagStyle = tagStyle({ name: theme.name, state: artifactState })
+  // const ArtifactStateTag = () => artifactState && (
+  //   <Tag
+  //     classes={['artifact-tag', 'state-tag']}
+  //     styles={artifactTagStyle}
+  //     text={artifactState}
+  //   />
+  // )
 
   const ArtifactMainButton = () => (
     <ArtifactActionButton
@@ -168,7 +164,7 @@ const ArtifactRow = ({
             <PlatformIcon />
             <ArtifactKindName />
             <BuildIdentifier />
-            <ArtifactStateTag />
+            {/* <ArtifactStateTag /> */}
           </div>
           {ArtifactLocalPathRow}
           <div className="block-details-row">

--- a/web/src/ui/components/Build/BuildBlockHeader.js
+++ b/web/src/ui/components/Build/BuildBlockHeader.js
@@ -1,38 +1,42 @@
+import classNames from 'classnames'
 import React, { useContext } from 'react'
 import {
-  GitCommit, GitMerge, ChevronUp, ChevronDown,
+  ChevronDown, ChevronUp, GitCommit, GitPullRequest,
 } from 'react-feather'
-import classNames from 'classnames'
-
+import { MR_STATE } from '../../../constants'
 import { ThemeContext } from '../../../store/ThemeStore'
+import { colors } from '../../styleTools/themes'
 import Author from '../Author/Author'
-
 import './Build.scss'
 
 const BuildBlockHeader = ({
-  isMasterBuildBranch,
-  buildHasMr,
+  blockTitle,
   buildAuthorAvatarUrl,
   buildAuthorId,
   buildAuthorName,
+  buildHasMr,
   collapsed,
-  toggleCollapsed,
-  blockTitle,
+  isMasterBuildBranch,
   latestBuildStateTags,
+  mrState,
+  toggleCollapsed,
 }) => {
   const { theme } = useContext(ThemeContext)
   const blockRowClassNames = classNames('block-row', { expanded: !collapsed })
-  const blockHeaderIconClassNames = classNames('block-left-icon', { 'rotate-merge': isMasterBuildBranch })
-  const blockHeaderIconColor = isMasterBuildBranch && buildHasMr ? theme.icon.masterGreen : theme.text.sectionText
+  const blockHeaderIconClassNames = classNames('block-left-icon')
+  const blockHeaderIconColorWithMr = mrState === MR_STATE.Merged ? colors.gitHub.ghMergedPurpleLighter : colors.gitHub.ghOpenGreen
+  const blockHeaderIconColor = buildHasMr && (mrState === MR_STATE.Merged || mrState === MR_STATE.Opened) ? blockHeaderIconColorWithMr : theme.text.sectionText
+  const BlockHeaderIcon = ({ color }) => mrState ? <GitPullRequest color={color} /> : <GitCommit color={color} />
 
   const BlockIconPullHasMr = () => (
     <div className={blockHeaderIconClassNames}>
-      <GitMerge color={blockHeaderIconColor} />
+      <BlockHeaderIcon color={blockHeaderIconColor} />
     </div>
   )
+
   const BlockIconDefault = () => (
     <div className={blockHeaderIconClassNames}>
-      <GitCommit color={blockHeaderIconColor} />
+      <BlockHeaderIcon color={blockHeaderIconColor} />
     </div>
   )
 

--- a/web/src/ui/components/Build/BuildContainer.js
+++ b/web/src/ui/components/Build/BuildContainer.js
@@ -34,6 +34,7 @@ const BuildContainer = ({
       short_id: mrShortId = '',
       id: mrId = '',
       title: mrTitle = '',
+      state: mrState = '',
       has_author: {
         name: buildAuthorName = '',
         id: buildAuthorId = '',
@@ -149,11 +150,11 @@ const BuildContainer = ({
             collapsed,
             isMasterBuildBranch,
             mrId,
+            mrState,
             mrShortId,
             toggleCollapsed,
             blockTitle,
             latestBuildStateTags,
-            AnyRunningBuildTags,
           }}
         />
         {!collapsed

--- a/web/src/ui/styleTools/themes.js
+++ b/web/src/ui/styleTools/themes.js
@@ -106,3 +106,12 @@ export const sharedThemes = {
     block: '20px',
   },
 }
+
+export const colors = {
+  gitHub: {
+    ghMergedPurple: '#6843bd', // too dark for our dark mode
+    ghMergedPurpleLighter: '#7c5dc3',
+    ghClosedRed: '#bd3434',
+    ghOpenGreen: '#5bbc58',
+  },
+}


### PR DESCRIPTION
- use GitHub colors and pull request icon for builds with GH MR attached
- fix up GH colors for our dark mode

![image](https://user-images.githubusercontent.com/24300177/82686368-10ba8080-9c56-11ea-952e-39f623c4051f.png)

---

Also:
- remove state tag from artifact row
