### PR TITLE
feat(front): request 25 builds if no UI filters are in place

### DIFF
--- a/web/src/constants/index.js
+++ b/web/src/constants/index.js
@@ -1,5 +1,7 @@
 import * as actions from './actions.js'
 
+export const DEFAULT_RESULT_REQUEST_LIMIT = 25
+
 export const KIND_TO_PLATFORM = {
   IPA: 'iOS',
   APK: 'Android',

--- a/web/src/ui/pages/Home/Home.js
+++ b/web/src/ui/pages/Home/Home.js
@@ -21,7 +21,7 @@ import { useHistory, useLocation } from 'react-router-dom'
 import { getBuildList } from '../../../api'
 import { validateError } from '../../../api/apiResponseTransforms'
 import {
-  ARTIFACT_KINDS, BUILD_DRIVERS, BUILD_STATES, PLATFORM_TO_ARTIFACT_KIND,
+  ARTIFACT_KINDS, BUILD_DRIVERS, BUILD_STATES, PLATFORM_TO_ARTIFACT_KIND, DEFAULT_RESULT_REQUEST_LIMIT,
 } from '../../../constants'
 import { INITIAL_STATE, ResultContext } from '../../../store/ResultStore'
 import { getMobileOperatingSystem } from '../../../util/browser'
@@ -158,7 +158,7 @@ const Home = ({ theme }) => {
       })
       history.push({
         path: '/',
-        search: queryString.stringify(state.uiFilters) || 'limit=15',
+        search: queryString.stringify(state.uiFilters) || `limit=${DEFAULT_RESULT_REQUEST_LIMIT}`,
       })
       setNeedsNewFetch(true)
     }


### PR DESCRIPTION
For performance reasons, limit API request to 25 builds if user has unselected all filters in UI.