### PR TITLE
chore: increase default cookie expiration

### DIFF
--- a/web/src/api/cookies.js
+++ b/web/src/api/cookies.js
@@ -3,7 +3,7 @@ import Cookies from 'js-cookie'
 export const retrieveAuthCookie = () => Cookies.get('apiKey')
 
 export const setAuthCookie = ({ apiKey }) => {
-  Cookies.set('apiKey', apiKey, { expires: 7 })
+  Cookies.set('apiKey', apiKey, { expires: 365 })
 }
 
 export const removeAuthCookie = () => {


### PR DESCRIPTION
there are no security/privacy concerns here, and this is typically the kind of app you don't open for weeks/months