### PR TITLE
refactor(front): split out build-block related subcomponents

### DIFF
--- a/web/src/ui/components/Author/Author.js
+++ b/web/src/ui/components/Author/Author.js
@@ -2,41 +2,59 @@ import React from 'react'
 import { User } from 'react-feather'
 import styles from './Author.module.scss'
 import withTheme from '../../helpers/withTheme'
+import ConditionallyWrappedComponent from '../ConditionallyWrappedComponent'
+
+const Avatar = ({
+  sectionText, buildAuthorAvatarUrl, buildAuthorId, buildAuthorName,
+}) => buildAuthorId && buildAuthorAvatarUrl ? (
+  <a href={buildAuthorId} title={buildAuthorId}>
+    <img src={buildAuthorAvatarUrl} alt={buildAuthorId} />
+  </a>
+) : (
+  <User
+    color={sectionText}
+    title={buildAuthorName || 'Unknown author'}
+  />
+)
+
+const AuthorName = ({
+  themeStyles, buildAuthorId, buildAuthorName,
+}) => (
+  <ConditionallyWrappedComponent
+    condition={!!buildAuthorId}
+    wrapper={(children) => (
+      <a
+        href={buildAuthorId}
+        className={styles['author-url-name']}
+        style={themeStyles.textSectionTitle}
+      >
+        {children}
+      </a>
+    )}
+  >
+    <small>{buildAuthorName}</small>
+  </ConditionallyWrappedComponent>
+)
 
 const Author = ({
-  authorName = '', authorUrl = '', avatarUrl = '', ...injectedProps
+  buildAuthorName = '', buildAuthorId = '', buildAuthorAvatarUrl = '', ...injectedProps
 }) => {
   const { theme: { text: { sectionText } }, themeStyles } = injectedProps
-  const Avatar = () => authorUrl && avatarUrl ? (
-    <a href={authorUrl} title={authorUrl}>
-      <img src={avatarUrl} alt={authorUrl} />
-    </a>
-  ) : (
-    <User
-      color={sectionText}
-      title={authorName || 'Unknown author'}
-    />
-  )
 
-  const AuthorName = () => authorUrl ? (
-    <a
-      href={authorUrl}
-      className={styles['author-url-name']}
-      style={themeStyles.textSectionTitle}
-    >
-      <small>{authorName}</small>
-    </a>
-  ) : (
-    <small>{authorName}</small>
-  )
 
   return (
     <div className={styles['author-wrapper']}>
       <div className={styles['author-name-wrapper']}>
-        <AuthorName />
+        <AuthorName {...{
+          buildAuthorId, buildAuthorName, buildAuthorAvatarUrl, themeStyles,
+        }}
+        />
       </div>
       <div className={styles['author-avatar-wrapper']}>
-        <Avatar />
+        <Avatar {...{
+          buildAuthorAvatarUrl, buildAuthorId, buildAuthorName, sectionText,
+        }}
+        />
       </div>
     </div>
   )

--- a/web/src/ui/components/Build/ArtifactRow.js
+++ b/web/src/ui/components/Build/ArtifactRow.js
@@ -71,7 +71,7 @@ const ArtifactQrButton = ({ onClick, theme }) => (
     }}
     title="Show QR code"
   >
-    <FontAwesomeIcon icon={faQrcode} size="2x" color={theme.text.blockTitle} style={{ marginTop: 0, marginBottom: 0, transform: 'scale(90%)' }} />
+    <FontAwesomeIcon icon={faQrcode} size="2x" color={theme.text.btnPrimary} style={{ marginTop: 0, marginBottom: 0, transform: 'scale(90%)' }} />
   </div>
 )
 

--- a/web/src/ui/components/Build/Build.scss
+++ b/web/src/ui/components/Build/Build.scss
@@ -126,10 +126,14 @@
             }
             .build-message-line {
                 flex-basis: 100%;
+                font-size: 85%;
                 &:last-of-type {
                     flex-basis: auto;
                     max-width: 80%;
                 }
+            }
+            .build-message-line-suffix {
+                font-size: 85%;
             }
             display: flex;
             flex: 1 1 100%;

--- a/web/src/ui/components/Build/BuildAndMrContainerWidgets.js
+++ b/web/src/ui/components/Build/BuildAndMrContainerWidgets.js
@@ -1,0 +1,130 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faAlignLeft, faPencilAlt, faHammer } from '@fortawesome/free-solid-svg-icons'
+import { faGithub } from '@fortawesome/free-brands-svg-icons'
+import {
+  GitCommit, AlertCircle, GitPullRequest, Calendar,
+} from 'react-feather'
+import { getRelativeTime, getTimeLabel } from '../../../util/date'
+import ConditionallyWrappedComponent from '../ConditionallyWrappedComponent'
+import { tagColorStyles } from '../../styleTools/buttonStyler'
+import Tag from '../Tag/Tag'
+import { MR_STATE } from '../../../constants'
+
+export const BuildUpdatedAt = ({ buildUpdatedAt, sectionText }) => {
+  const timeSinceUpdated = getRelativeTime(buildUpdatedAt)
+  return timeSinceUpdated && (
+    <Tag
+      classes={['normal-caps', 'details']}
+      title={getTimeLabel('Build updated', buildUpdatedAt)}
+      icon={<FontAwesomeIcon icon={faPencilAlt} color={sectionText} />}
+      text={timeSinceUpdated}
+    />
+  )
+}
+
+export const BuildLogs = ({ buildId, blockTitle }) => (
+  <a href={buildId}>
+    <FontAwesomeIcon
+      icon={faAlignLeft}
+      color={blockTitle}
+      size="lg"
+      title={buildId}
+      style={{ marginBottom: '0.7rem' }}
+    />
+  </a>
+)
+
+export const GithubLink = ({ buildProjectUrl, blockTitle }) => buildProjectUrl && (
+  <a href={buildProjectUrl}>
+    <FontAwesomeIcon
+      icon={faGithub}
+      color={blockTitle}
+      size="lg"
+      title={buildProjectUrl}
+    />
+  </a>
+)
+
+export const BuildDriver = ({ buildDriver, sectionText }) => buildDriver && (
+  <Tag
+    classes={['normal-caps', 'details']}
+    title={`Build driver: ${buildDriver}`}
+    icon={<FontAwesomeIcon icon={faHammer} color={sectionText} />}
+    text={`Build driver: ${buildDriver}`}
+  />
+)
+
+export const MrDriver = ({ mrDriver, sectionText }) => mrDriver && (
+  <Tag
+    classes={['normal-caps', 'details']}
+    title={`Merge request driver: ${mrDriver}`}
+    icon={<FontAwesomeIcon icon={faHammer} color={sectionText} />}
+    text={mrDriver}
+  />
+)
+
+export const BuildCommit = ({ buildCommitId, mrCommitUrl, colorInteractiveText }) => {
+  const COMMIT_LEN = 7
+  return buildCommitId && (
+    <div title={buildCommitId}>
+      Commit
+      {' '}
+      <ConditionallyWrappedComponent
+        condition={!!mrCommitUrl}
+        wrapper={(children) => (
+          <a href={mrCommitUrl} style={colorInteractiveText} className="interactive-text">
+            {children}
+          </a>
+        )}
+      >
+        {buildCommitId.slice(0, COMMIT_LEN)}
+      </ConditionallyWrappedComponent>
+    </div>
+  )
+}
+
+export const BuildCreatedAt = ({ buildCreatedAt }) => {
+  const timeSinceCreated = getRelativeTime(buildCreatedAt)
+  return timeSinceCreated && (
+    <Tag
+      text={timeSinceCreated}
+      icon={<Calendar />}
+      classes={['normal-caps', 'details']}
+      title={getTimeLabel('Build created', buildCreatedAt)}
+    />
+  )
+}
+
+export const MrState = ({ mrState, theme }) => mrState && (
+  <Tag
+    title="Merge request state"
+    classes={['btn-primary', 'state-tag']}
+    styles={tagColorStyles({ theme, state: MR_STATE[mrState] })}
+    icon={
+      mrState === MR_STATE.Opened ? (
+        <AlertCircle style={{ marginRight: '0.2rem' }} />
+      ) : (
+        <GitPullRequest style={{ marginRight: '0.2rem' }} />
+      )
+    }
+    text={mrState}
+  />
+)
+
+export const CommitIcon = ({
+  colorInteractiveText, buildCommitId, mrCommitUrl, buildHasMr,
+}) => (
+  <ConditionallyWrappedComponent
+    condition={!!mrCommitUrl}
+    wrapper={
+        (children) => (
+          <a href={mrCommitUrl} style={colorInteractiveText}>
+            {children}
+          </a>
+        )
+      }
+  >
+    <GitCommit title={buildCommitId || ''} style={buildHasMr ? {} : { transform: 'rotate(90deg)' }} />
+  </ConditionallyWrappedComponent>
+)

--- a/web/src/ui/components/Build/BuildBlockHeader.js
+++ b/web/src/ui/components/Build/BuildBlockHeader.js
@@ -6,74 +6,79 @@ import {
 import { MR_STATE } from '../../../constants'
 import { ThemeContext } from '../../../store/ThemeStore'
 import { colors } from '../../styleTools/themes'
-import Author from '../Author/Author'
 import './Build.scss'
+import BuildBlockTitle from './BuildBlockTitle'
+import Author from '../Author/Author'
+
+const BlockIcon = ({ theme, mrState, buildHasMr }) => {
+  const blockHeaderIconClassNames = classNames('block-left-icon')
+  const blockHeaderIconColorWithMr = mrState === MR_STATE.Merged ? colors.gitHub.ghMergedPurpleLighter : colors.gitHub.ghOpenGreen
+  const blockHeaderIconColor = buildHasMr && (mrState === MR_STATE.Merged || mrState === MR_STATE.Opened) ? blockHeaderIconColorWithMr : theme.text.sectionText
+
+  const BlockHeaderIcon = () => mrState ? <GitPullRequest color={blockHeaderIconColor} /> : <GitCommit color={blockHeaderIconColor} />
+  return (
+    <div className={blockHeaderIconClassNames}>
+      <BlockHeaderIcon />
+    </div>
+  )
+}
+
+const ChevronIcon = ({ theme, collapsed, toggleCollapsed }) => (
+  <div
+    style={{
+      color: theme.text.blockTitle,
+      cursor: 'pointer',
+      flexShrink: 0,
+    }}
+    onClick={() => toggleCollapsed(!collapsed)}
+  >
+    {!collapsed ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+  </div>
+)
+
 
 const BuildBlockHeader = ({
-  blockTitle,
+  buildAuthorName,
   buildAuthorAvatarUrl,
   buildAuthorId,
-  buildAuthorName,
   buildHasMr,
+  buildId,
+  buildShortId,
+  mrShortId,
+  mrId,
+  mrTitle,
+  childrenLatestBuildTags,
   collapsed,
   isMasterBuildBranch,
-  latestBuildStateTags,
   mrState,
   toggleCollapsed,
 }) => {
   const { theme } = useContext(ThemeContext)
   const blockRowClassNames = classNames('block-row', { expanded: !collapsed })
-  const blockHeaderIconClassNames = classNames('block-left-icon')
-  const blockHeaderIconColorWithMr = mrState === MR_STATE.Merged ? colors.gitHub.ghMergedPurpleLighter : colors.gitHub.ghOpenGreen
-  const blockHeaderIconColor = buildHasMr && (mrState === MR_STATE.Merged || mrState === MR_STATE.Opened) ? blockHeaderIconColorWithMr : theme.text.sectionText
-  const BlockHeaderIcon = ({ color }) => mrState ? <GitPullRequest color={color} /> : <GitCommit color={color} />
-
-  const BlockIconPullHasMr = () => (
-    <div className={blockHeaderIconClassNames}>
-      <BlockHeaderIcon color={blockHeaderIconColor} />
-    </div>
-  )
-
-  const BlockIconDefault = () => (
-    <div className={blockHeaderIconClassNames}>
-      <BlockHeaderIcon color={blockHeaderIconColor} />
-    </div>
-  )
-
-  const BlockIcon = () => (!isMasterBuildBranch && buildHasMr ? <BlockIconPullHasMr /> : <BlockIconDefault />)
-
-  const ChevronIcon = () => (
-    <div
-      style={{
-        color: theme.text.blockTitle,
-        cursor: 'pointer',
-        flexShrink: 0,
-      }}
-      onClick={() => toggleCollapsed(!collapsed)}
-    >
-      {!collapsed ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-    </div>
-  )
 
   return (
     <>
       <div className={blockRowClassNames}>
-        <BlockIcon />
-        {blockTitle}
-
-        <Author
-          authorName={buildAuthorName || undefined}
-          authorUrl={buildAuthorId}
-          avatarUrl={buildAuthorAvatarUrl}
+        <BlockIcon {...{ theme, buildHasMr, mrState }} />
+        <BuildBlockTitle {...{
+          isMasterBuildBranch,
+          buildShortId,
+          mrShortId,
+          buildId,
+          mrId,
+          mrTitle,
+          buildHasMr,
+        }}
         />
-        <ChevronIcon />
+        <Author {...{ buildAuthorAvatarUrl, buildAuthorName, buildAuthorId }} />
+        <ChevronIcon {...{ theme, collapsed, toggleCollapsed }} />
       </div>
-      {collapsed && latestBuildStateTags && (
+      {collapsed && childrenLatestBuildTags && (
         <div
           className={blockRowClassNames}
           style={{ display: 'flex', flexWrap: 'wrap' }}
         >
-          {latestBuildStateTags}
+          {childrenLatestBuildTags}
         </div>
       )}
     </>

--- a/web/src/ui/components/Build/BuildMessage.js
+++ b/web/src/ui/components/Build/BuildMessage.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import ConditionallyWrappedComponent from '../ConditionallyWrappedComponent'
+
+const SplitMessage = ({ text }) => (
+  <>
+    {text.split('\n').filter((x) => !!x).map((x, i) => (
+      <p className="build-message-line" key={i}>{x}</p>
+    ))}
+  </>
+)
+
+const LongBuildMessage = ({
+  children, colorInteractiveText, toggleMessageExpanded, messageExpanded,
+}) => (
+  <div className="interactive-text build-message" onClick={() => toggleMessageExpanded(!messageExpanded)}>
+    {children}
+    <span className="build-message-line-suffix" style={colorInteractiveText}>
+      {!messageExpanded ? '... [show more]' : ' [show less]'}
+    </span>
+  </div>
+)
+
+const BuildMessage = ({
+  buildMessage = '', colorInteractiveText, messageExpanded, toggleMessageExpanded,
+}) => {
+  const MESSAGE_LEN = 140
+  const isLong = buildMessage.length > MESSAGE_LEN
+  const text = !isLong || messageExpanded ? buildMessage : buildMessage.slice(0, MESSAGE_LEN)
+  return (
+    <ConditionallyWrappedComponent
+      condition={isLong}
+      wrapper={(children) => (
+        <LongBuildMessage {...{ colorInteractiveText, messageExpanded, toggleMessageExpanded }}>
+          {children}
+        </LongBuildMessage>
+      )}
+    >
+      <SplitMessage text={text} />
+    </ConditionallyWrappedComponent>
+  )
+}
+
+export default BuildMessage

--- a/web/src/ui/components/ConditionallyWrappedComponent.js
+++ b/web/src/ui/components/ConditionallyWrappedComponent.js
@@ -1,0 +1,3 @@
+const ConditionallyWrappedComponent = ({ condition, wrapper, children }) => condition ? wrapper(children) : children
+
+export default ConditionallyWrappedComponent

--- a/web/src/ui/components/ShowingOlderBuildsTag.js
+++ b/web/src/ui/components/ShowingOlderBuildsTag.js
@@ -1,11 +1,11 @@
 
 import React from 'react'
 import { ChevronDown, ChevronUp } from 'react-feather'
-import { tagStyle } from '../styleTools/buttonStyler'
+import { tagColorStyles } from '../styleTools/buttonStyler'
 import Tag from './Tag/Tag'
 import withTheme from '../helpers/withTheme'
 
-const ShownBuildsButton = ({
+const ShowingOlderBuildsTag = ({
   nOlderBuilds,
   showingAllBuilds = null,
   toggleShowingAllBuilds = null,
@@ -13,9 +13,9 @@ const ShownBuildsButton = ({
 }) => {
   const {
     theme: {
-      name,
       text: { blockTitle },
     },
+    theme,
   } = injectedProps
 
   const multipleOlderBuilds = nOlderBuilds > 1
@@ -23,7 +23,7 @@ const ShownBuildsButton = ({
 
   const messagePrefix = showingAllBuilds ? 'hide' : 'show'
 
-  const message = nOlderBuilds
+  const message = nOlderBuilds > 0
     ? `${isInteractive ? messagePrefix : ''} ${nOlderBuilds} older build${
       multipleOlderBuilds ? 's' : ''
     }`
@@ -33,27 +33,26 @@ const ShownBuildsButton = ({
     : <ChevronDown color={blockTitle} />
   )
 
-  const ShownBuildsTag = () => (
+  return (message
+    && (
     <Tag
       classes={['btn-info-tag']}
       title={message}
-      styles={tagStyle({
-        name,
-        state: null,
-        cursor: !isInteractive ? undefined : 'pointer',
-      })}
+      styles={{
+        ...tagColorStyles({
+          theme,
+          state: null,
+
+        }),
+        cursor: !isInteractive ? 'default' : 'pointer',
+      }}
       onClick={!isInteractive ? undefined : () => toggleShowingAllBuilds(!showingAllBuilds)}
     >
       {isInteractive && <Icon />}
       {message}
     </Tag>
-  )
-
-  return (
-    <>
-      {message && <ShownBuildsTag />}
-    </>
+    )
   )
 }
 
-export default withTheme(ShownBuildsButton)
+export default withTheme(ShowingOlderBuildsTag)

--- a/web/src/ui/styleTools/buttonStyler.js
+++ b/web/src/ui/styleTools/buttonStyler.js
@@ -1,9 +1,6 @@
-import { themes } from './themes'
 import { BUILD_STATE, ARTIFACT_STATE } from '../../constants'
 
-export const tagStyle = ({ name, state = null, cursor = 'default' }) => {
-  const theme = themes[name] || themes.dark
-
+export const tagColorStyles = ({ theme, state = null }) => {
   const styles = {
     [ARTIFACT_STATE.Finished]: {
       backgroundColor: theme.bg.tagGreen,
@@ -35,39 +32,12 @@ export const tagStyle = ({ name, state = null, cursor = 'default' }) => {
       border: '1px solid gray',
     },
   }
-  const style = styles[state] || styles.DEFAULT
-  return { ...style, cursor }
-}
-
-export const actionButtonColorsShadow = ({ name, state }) => {
-  const theme = themes[name] || themes.light
-  const styles = {
-    // [ARTIFACT_STATE.Finished]: {
-    //   backgroundColor: theme.bg.tagGreen,
-    //   color: theme.text.tagGreen,
-    //   boxShadow: `0px 0.25rem 0px ${theme.shadow.btnDlMaster}`,
-    // },
-    [ARTIFACT_STATE.Finished]: {
-      backgroundColor: theme.bg.btnPrimary,
-      // color: theme.text.tagGreen,
-      color: theme.text.blockTitle,
-      border: `1px solid ${theme.bg.btnPrimary}`,
-      boxShadow: `0px 0.25rem 0px ${theme.shadow.btnPrimary}`,
-    },
-    [ARTIFACT_STATE.Building]: { display: 'none' },
-    [ARTIFACT_STATE.Error]: {
-      backgroundColor: theme.bg.tagPink,
-      color: theme.text.tagPink,
-      cursor: 'default',
-    },
-    DEFAULT: { display: 'none' },
-  }
   return styles[state] || styles.DEFAULT
 }
 
 export const primaryButtonColors = (theme) => ({
   backgroundColor: theme.bg.btnPrimary,
   border: `1px solid ${theme.bg.btnPrimary}`,
-  color: theme.text.blockTitle,
+  color: theme.text.btnPrimary,
   boxShadow: `0px 4px 0px ${theme.shadow.btnPrimary}`,
 })

--- a/web/src/ui/styleTools/themes.js
+++ b/web/src/ui/styleTools/themes.js
@@ -21,6 +21,7 @@ export const themes = {
       tagGreen: '#20d6b5',
       tagPink: '#fe497f',
       tagOrange: '#ffae3a',
+      btnPrimary: '#fcfcff', // not from spec
       filterUnselectedTitle: '#888aa1',
       filterSelectedTitle: '#3f49ea',
     },
@@ -68,6 +69,7 @@ export const themes = {
       tagGreen: '#23928e',
       tagPink: '#d23064',
       tagOrange: '#ff9a0b',
+      btnPrimary: '#cdcfed', // not from spec
       filterUnselectedTitle: '#7c7ea1',
       filterSelectedTitle: '#7373f6',
     },
@@ -92,18 +94,6 @@ export const themes = {
     shadowStyle: {
       block: 'none',
     },
-  },
-}
-
-export const sharedThemes = {
-  borderRadius: {
-    block: '15px',
-  },
-  padding: {
-    block: '15px',
-  },
-  marginBottom: {
-    block: '20px',
   },
 }
 


### PR DESCRIPTION
- Splits out most nested components inside `src/ui/components/Build` (everything related to API response with build data)
- Renames some variables and files for clarity (still some work left to do on this)
- Removes some unused abstractions and styling tools

Unrelated:
- Theme fix: Add primary button color