### PR TITLE
feat(front): show latest master builds at top of feed

### DIFF
--- a/web/src/api/apiResponseTransforms.js
+++ b/web/src/api/apiResponseTransforms.js
@@ -1,4 +1,4 @@
-import { values } from 'lodash'
+import { values, uniq } from 'lodash'
 import { getSafeStr } from '../util/getters'
 import { getIsNextDay } from '../util/date'
 
@@ -68,6 +68,26 @@ const groupByMr = (acc = {}, build, i) => {
  * @return {Array<BuildObject>}
  */
 export const groupBuildsByMr = (builds) => values(builds.reduce(groupByMr, {}))
+
+/**
+ * Gets index of builds in the top-level builds you want to list
+ * that have branch Master and are the most recent for each unique project in API results
+ *
+ * Build must have has_project_id: string field
+ *
+ * Assumes builds are sorted in descending order by build.created_at
+ *)
+ *
+ * @param  {Array<BuildObject>} sortedTopLevelBuilds
+ * @return {Array<Number>}
+ */
+export const getLatestMasterBuildsForProjects = (sortedTopLevelBuilds) => {
+  const uniqueProjects = uniq(sortedTopLevelBuilds.map((b) => b.has_project_id))
+  const latestMasterBuildPerProject = uniqueProjects
+    .map((p) => sortedTopLevelBuilds
+      .findIndex((build) => build.has_project_id && build.has_project_id === p))
+  return latestMasterBuildPerProject
+}
 
 /**
  * Takes axios HTTP error and formats it

--- a/web/src/ui/components/BuildList.js
+++ b/web/src/ui/components/BuildList.js
@@ -8,28 +8,47 @@ import {
 import {
   groupBuildsByMr,
   flagBuildsFirstOfDay,
+  getLatestMasterBuildsForProjects,
 } from '../../api/apiResponseTransforms'
 import Divider from './Divider/Divider'
 import { getDayFormat } from '../../util/date'
+import { getIsArrayWithN } from '../../util/getters'
 
 const BuildList = React.memo(({ builds = [], loaded }) => {
   const oneBuildInResultsHasMaster = useMemo(() => oneBuildResultHasBranchMaster(builds), [builds])
   const buildsByMr = useMemo(() => flagBuildsFirstOfDay(groupBuildsByMr(builds)), [builds])
+  const latestMasterBuildsForProjects = !getIsArrayWithN(buildsByMr, 2) || !oneBuildInResultsHasMaster ? [] : getLatestMasterBuildsForProjects(buildsByMr)
   const NoBuilds = () => <div>No results match your query.</div>
 
   return !builds.length && loaded ? (
     <NoBuilds />
   ) : (
     <div className="container">
+      {latestMasterBuildsForProjects.length > 0 && buildsByMr
+        .filter((_, i) => latestMasterBuildsForProjects.includes(i))
+        .map((build, i) => (
+          <BuildContainer
+            key={`${build.id}-${i}`}
+            build={build}
+            toCollapse={false}
+            hasRunningBuilds={buildsStateIsRunning(build.allBuildsForMr, builds)}
+          >
+            {i === 0 && (
+            <Divider dividerText="Latest builds on Master" />
+            )}
+          </BuildContainer>
+        ))}
+      {latestMasterBuildsForProjects.length > 0
+          && <Divider dividerText="All builds by date" />}
       {buildsByMr.map((build, i) => (
         <BuildContainer
           key={`${build.id}-${i}`}
           build={build}
-          toCollapse={oneBuildInResultsHasMaster && !buildBranchIsMaster(build)}
+          toCollapse={latestMasterBuildsForProjects.includes(i) || (oneBuildInResultsHasMaster && !buildBranchIsMaster(build))}
           hasRunningBuilds={buildsStateIsRunning(build.allBuildsForMr, builds)}
         >
           {build.buildIsFirstOfDay && (
-          <Divider dividerText={getDayFormat(build.created_at)} />
+          <h4>{getDayFormat(build.created_at)}</h4>
           )}
 
         </BuildContainer>

--- a/web/src/util/date.js
+++ b/web/src/util/date.js
@@ -2,10 +2,12 @@ import dayjs from 'dayjs'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
+import isToday from 'dayjs/plugin/isToday'
 
 dayjs.extend(localizedFormat)
 dayjs.extend(advancedFormat)
 dayjs.extend(relativeTime)
+dayjs.extend(isToday)
 
 const getDay = (rawDate, formatString = 'YYYY-MM-DDTHH:mm:ssZ') => {
   const isValid = dayjs(rawDate, formatString).isValid()
@@ -32,7 +34,9 @@ export const getDayFormat = (
   formatString = 'YYYY-MM-DDTHH:mm:ssZ',
 ) => {
   const date = dayjs(rawDate, formatString)
-  return date.isValid() ? date.format('LL') : ''
+  const today = () => date.isToday() ? 'Today' : ''
+  const dayFormatted = () => date.format('LL')
+  return date.isValid() && (today() || dayFormatted())
 }
 
 export const getRelativeTime = (


### PR DESCRIPTION
- If there are > 1 builds (grouped by MR, if one exists) for a project/projects, and the grouped build is on branch master, they are shown at the top of feed
- There can be > 1 build in this top section if there are multiple projects in the results list
- Any builds in this section will be shown in the "All builds by date" section too, but collapsed by default

Relates to #328 (still need to treat running builds)
