### PR TITLE
feat: add an helper to extract a file from an artifact

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,6 @@ require (
 	moul.io/depviz/v3 v3.11.4
 	moul.io/godev v1.6.0
 	moul.io/hcfilters v1.3.0
-	moul.io/pkgman v1.2.1
+	moul.io/pkgman v1.2.2
 	moul.io/zapgorm v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/tracer v0.0.0-20140124184152-66d3696bba97 h1:ZXZ3Ko4supnaInt/pSZnq3QL65Qx/KSZTUPMJH5RlIk=
 github.com/stretchr/tracer v0.0.0-20140124184152-66d3696bba97/go.mod h1:H0mYc1JTiYc9K0keLMYcR2ybyeom20X4cOYrKya1M1Y=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
@@ -567,8 +569,8 @@ moul.io/graphman/viz v0.0.0-20200301205736-d14252ef2f07/go.mod h1:LrMvUXoSlBip3Z
 moul.io/hcfilters v1.3.0 h1:PsZKgLK0p4JkTHfWh1v0c3pMCnzywgXt9NYZUNsNdwE=
 moul.io/hcfilters v1.3.0/go.mod h1:fXFpC8iYgb/Lfnt/e5yB1NM74yq5Lch99VytoAZnaWc=
 moul.io/multipmuri v1.13.0/go.mod h1:NinVrznZaHGUDU+4zfcL7L9WzMsHtb/kjLr4RaCbM+c=
-moul.io/pkgman v1.2.1 h1:Gq1qgpS4RHEJFz/furgU+uaJyFKUWzpyhyhrUPMm7Pk=
-moul.io/pkgman v1.2.1/go.mod h1:Q+2jtriM2phG+nsdyAmc262pfqr9CGT0SKe1Ea1xkeA=
+moul.io/pkgman v1.2.2 h1:oLT/oEINIBsAuNE4GpK1L97fU1ypaLlOr8n8EdZyzS0=
+moul.io/pkgman v1.2.2/go.mod h1:rVsnDN/+htSk94lVRAv1UWwlaurLdlBWg3MfQpqtzQU=
 moul.io/srand v1.4.0/go.mod h1:P2uaZB+GFstFNo8sEj6/U8FRV1n25kD0LLckFpJ+qvc=
 moul.io/zapgorm v1.0.0 h1:HpO9x1TmsKFd4JoLNHrSIc1uZn6kmyDxLQK4xjfz8JE=
 moul.io/zapgorm v1.0.0/go.mod h1:JDE3xz5BQ1ccnAijE5+T8Qin6T256Bw2Cpdi+qMfWgw=

--- a/go/pkg/yolosvc/api_artifactgetfile.go
+++ b/go/pkg/yolosvc/api_artifactgetfile.go
@@ -1,0 +1,57 @@
+package yolosvc
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"berty.tech/yolo/v2/go/pkg/yolopb"
+	"github.com/go-chi/chi"
+	"google.golang.org/grpc/codes"
+	"moul.io/pkgman/pkg/ipa"
+)
+
+func (svc *service) ArtifactGetFile(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "artifactID")
+	filePath := chi.URLParam(r, "*")
+	fmt.Println("id", id, "path", filePath)
+
+	var artifact yolopb.Artifact
+	err := svc.db.
+		Preload("HasBuild").
+		Preload("HasBuild.HasProject").
+		Preload("HasBuild.HasProject.HasOwner").
+		First(&artifact, "ID = ?", id).
+		Error
+	if err != nil {
+		httpError(w, err, codes.InvalidArgument)
+		return
+	}
+
+	artifactPath := filepath.Join(svc.artifactsCachePath, artifact.ID)
+	if !fileExists(artifactPath) {
+		httpError(w, err, codes.NotFound)
+		return
+	}
+
+	pkg, err := ipa.Open(artifactPath)
+	if err != nil {
+		httpError(w, err, codes.NotFound)
+		return
+	}
+	defer pkg.Close()
+
+	b, err := pkg.FileBytes(filePath)
+	if err != nil {
+		httpError(w, err, codes.NotFound)
+		return
+	}
+
+	contentType := mimetypeByPath(filePath)
+	w.Header().Add("Content-Type", contentType)
+
+	_, err = w.Write(b)
+	if err != nil {
+		httpError(w, err, codes.Internal)
+	}
+}

--- a/go/pkg/yolosvc/api_download.go
+++ b/go/pkg/yolosvc/api_download.go
@@ -41,7 +41,7 @@ func (svc *service) ArtifactDownloader(w http.ResponseWriter, r *http.Request) {
 	}
 
 	base := path.Base(artifact.LocalPath)
-	w.Header().Add("Content-Disposition", fmt.Sprintf("inline; filename=%s", base))
+	w.Header().Add("Content-Disposition", fmt.Sprintf("attachment; filename=%s", base))
 	if artifact.FileSize > 0 {
 		w.Header().Add("Content-Length", fmt.Sprintf("%d", artifact.FileSize))
 	}

--- a/go/pkg/yolosvc/server.go
+++ b/go/pkg/yolosvc/server.go
@@ -161,6 +161,7 @@ func NewServer(ctx context.Context, svc Service, opts ServerOpts) (*Server, erro
 		r.Get("/plist-gen/{artifactID}.plist", svc.PlistGenerator)
 		r.Get("/artifact-dl/{artifactID}", svc.ArtifactDownloader)
 		r.Get("/artifact-icon/{name}", svc.ArtifactIcon)
+		r.Get("/artifact-get-file/{artifactID}/*", svc.ArtifactGetFile)
 	})
 
 	box := packr.New("web", "../../../web")

--- a/go/pkg/yolosvc/service.go
+++ b/go/pkg/yolosvc/service.go
@@ -21,6 +21,7 @@ type Service interface {
 	PlistGenerator(w http.ResponseWriter, r *http.Request)
 	ArtifactDownloader(w http.ResponseWriter, r *http.Request)
 	ArtifactIcon(w http.ResponseWriter, r *http.Request)
+	ArtifactGetFile(w http.ResponseWriter, r *http.Request)
 
 	GitHubWorker(ctx context.Context, opts GithubWorkerOpts) error
 	BuildkiteWorker(ctx context.Context, opts BuildkiteWorkerOpts) error

--- a/go/pkg/yolosvc/util.go
+++ b/go/pkg/yolosvc/util.go
@@ -43,6 +43,8 @@ func mimetypeByPath(path string) string {
 		return "application/json"
 	case ".zip":
 		return "application/zip"
+	case ".plist":
+		return "application/x-plist"
 	}
 	return "application/octet-stream"
 }


### PR DESCRIPTION
    moul@fwrz:~ $ http --auth :uns3cur3 http://localhost:8067/api/artifact-get-file/buildkite_4a7ff9305bb3cb504d396edbf07c27bb/Payload/Berty%20Yolo.app/Info.plist
    HTTP/1.1 200 OK
    Content-Type: application/x-plist
    Date: Mon, 08 Jun 2020 21:24:34 GMT
    Transfer-Encoding: chunked
    Vary: Origin

    +-----------------------------------------+
    | NOTE: binary data not shown in terminal |
    +-----------------------------------------+

    moul@fwrz:~ $