### PR TITLE
chore: update default options

### DIFF
--- a/web/src/constants/index.js
+++ b/web/src/constants/index.js
@@ -95,11 +95,6 @@ export const BUILD_DRIVER_NAMES = {
 
 export const BUILD_DRIVERS = Object.values(BUILD_DRIVER_VALUE)
 
-export const PROJECT_BUILD_DRIVER = {
-  messenger: BUILD_DRIVER_VALUE.GitHub,
-  'gomobile-ipfs-demo': BUILD_DRIVER_VALUE.Bintray,
-}
-
 export const PROJECT_ARTIFACT_KINDS = {
   messenger: [ARTIFACT_KIND_VALUE.IPA],
   'gomobile-ipfs-demo': [ARTIFACT_KIND_VALUE.APK, ARTIFACT_KIND_VALUE.IPA],

--- a/web/src/hooks/queryHooks.js
+++ b/web/src/hooks/queryHooks.js
@@ -76,7 +76,7 @@ export const useSetFiltersOnQueryChange = () => {
   const { search: locationSearch } = useLocation()
   useEffect(() => {
     const updateFilters = () => {
-      const { artifact_kinds, build_driver, build_state } = JSON.parse(window.localStorage.getItem("uiFilters")) || getFiltersFromUrlQuery({ locationSearch }) || {}
+      const { artifact_kinds, build_driver, build_state } = JSON.parse(window.localStorage.getItem('uiFilters')) || getFiltersFromUrlQuery({ locationSearch }) || {}
       dispatch({
         type: actions.UPDATE_UI_FILTERS,
         payload: { artifact_kinds, build_driver, build_state },

--- a/web/src/store/GlobalStore.js
+++ b/web/src/store/GlobalStore.js
@@ -35,7 +35,7 @@ export const INITIAL_STATE = {
     build_state: [],
   },
   calculatedFilters: {
-    projects: JSON.parse(window.localStorage.getItem("projects")) || [PROJECT.messenger],
+    projects: JSON.parse(window.localStorage.getItem('projects')) || [PROJECT.messenger],
     order: 'created_at',
   },
   showingFilterModal: false,
@@ -58,8 +58,8 @@ function reducer(state, action) {
       }
     }
     case actions.LOGOUT:
-      window.localStorage.removeItem("projects")
-      window.localStorage.removeItem("uiFilters")
+      window.localStorage.removeItem('projects')
+      window.localStorage.removeItem('uiFilters')
       return {
         ...state,
         autoRefreshOn: false,

--- a/web/src/store/ThemeStore.js
+++ b/web/src/store/ThemeStore.js
@@ -14,7 +14,7 @@ export const ThemeStore = ({ children }) => {
   const [theme, setTheme] = useState(themes.dark)
 
   const changeTheme = (newName) => {
-    window.localStorage.setItem("theme", newName)
+    window.localStorage.setItem('theme', newName)
     setTheme(themes[newName] || themes.dark)
   }
 
@@ -45,7 +45,7 @@ export const ThemeStore = ({ children }) => {
   }, [theme])
 
   useEffect(() => {
-    const lTheme = window.localStorage.getItem("theme")
+    const lTheme = window.localStorage.getItem('theme')
     if (lTheme) {
       changeTheme(lTheme)
       return

--- a/web/src/store/globalStoreHelpers.js
+++ b/web/src/store/globalStoreHelpers.js
@@ -1,7 +1,12 @@
 import queryString from 'query-string'
 import { isEqual } from 'lodash'
 import {
-  ARTIFACT_KINDS, BUILD_DRIVERS, BUILD_STATES, KIND_TO_PLATFORM, PLATFORM_TO_ARTIFACT_KIND, PROJECT_BUILD_DRIVER, PROJECT_ARTIFACT_KINDS,
+  ARTIFACT_KINDS,
+  BUILD_DRIVERS,
+  BUILD_STATES,
+  KIND_TO_PLATFORM,
+  PLATFORM_TO_ARTIFACT_KIND,
+  PROJECT_ARTIFACT_KINDS,
 } from '../constants'
 import { singleItemToArray } from '../util/getters'
 import { getMobileOperatingSystem } from '../util/browser'
@@ -26,22 +31,34 @@ export const getFiltersFromUrlQuery = ({ locationSearch = '', uiFilters }) => {
     : queryBuildDrivers
   ).filter((buildDriver) => BUILD_DRIVERS.includes(buildDriver))
 
-  const buildStates = queryBuildState ? singleItemToArray(queryBuildState.toString())
-    .filter((buildState) => BUILD_STATES.includes(buildState)) : []
+  const buildStates = queryBuildState
+    ? singleItemToArray(queryBuildState.toString()).filter((buildState) => BUILD_STATES.includes(buildState))
+    : []
 
-  return ({ artifact_kinds: artifactKinds, build_driver: buildDrivers, build_state: buildStates })
+  return {
+    artifact_kinds: artifactKinds,
+    build_driver: buildDrivers,
+    build_state: buildStates,
+  }
 }
 
+// Set default query string:
+// project_id=__BERTY MESSENGER ID__
+// artifact_kinds=__MOBILE USER AGENT APP KIND || IPA__
 export const getFallbackQueryString = ({ userAgent = '', updateState }) => {
   const defaultArtifactKinds = [PROJECT_ARTIFACT_KINDS.messenger]
-  const defaultBuildDriver = [PROJECT_BUILD_DRIVER.messenger]
-  const userAgentToSetDefaultFilters = userAgent || getMobileOperatingSystem()
-  const isMobile = (userAgentToSetDefaultFilters === KIND_TO_PLATFORM.IPA || userAgentToSetDefaultFilters === KIND_TO_PLATFORM.APK)
-  const defaultKind = isMobile ? [PLATFORM_TO_ARTIFACT_KIND[userAgentToSetDefaultFilters]] : [...defaultArtifactKinds]
+  const updatedUserAgent = userAgent || getMobileOperatingSystem()
+  const isMobile = updatedUserAgent === KIND_TO_PLATFORM.IPA
+    || updatedUserAgent === KIND_TO_PLATFORM.APK
+  const defaultKind = isMobile
+    ? [PLATFORM_TO_ARTIFACT_KIND[updatedUserAgent]]
+    : defaultArtifactKinds
 
   updateState({
     userAgent,
   })
-  const fallbackQueryString = queryString.stringify({ artifact_kinds: defaultKind, build_driver: defaultBuildDriver })
+  const fallbackQueryString = queryString
+    .stringify({ artifact_kinds: defaultKind })
+    .concat('&project_id=https://github.com/berty/berty')
   return fallbackQueryString
 }

--- a/web/src/ui/components/BuildList.js
+++ b/web/src/ui/components/BuildList.js
@@ -81,7 +81,10 @@ const BuildList = ({ builds = [], loaded }) => {
   return !builds.length > 0 && loaded ? (
     <NoBuilds />
   ) : (
-    <div className="container">
+    <div
+      className="container"
+      style={{ alignSelf: 'flex-start', minHeight: '100%' }}
+    >
       {indexOfLatestMasterBuildsForProjects.length > 0
         && buildsByMrWithDateFlags
           .filter((_, i) => indexOfLatestMasterBuildsForProjects.includes(i))

--- a/web/src/ui/components/FilterModal/FilterModal.js
+++ b/web/src/ui/components/FilterModal/FilterModal.js
@@ -5,7 +5,12 @@ import { Check, LogOut } from 'react-feather'
 import { useHistory } from 'react-router-dom'
 import { removeAuthCookie } from '../../../api/cookies'
 import {
-  ARTIFACT_KINDS, BUILD_DRIVERS, BUILD_STATES, PROJECT, PROJECTS, actions,
+  ARTIFACT_KINDS,
+  BUILD_DRIVERS,
+  BUILD_STATES,
+  PROJECT,
+  PROJECTS,
+  actions,
 } from '../../../constants'
 import { GlobalContext } from '../../../store/GlobalStore'
 import { ThemeContext } from '../../../store/ThemeStore'
@@ -14,13 +19,20 @@ import Tag from '../Tag/Tag'
 import ThemeToggler from '../ThemeToggler'
 import styles from './FilterModal.module.scss'
 import {
-  ArtifactFilter, BranchFilter, BuildDriverFilter, BuildStateFilter, ProjectFilter,
+  ArtifactFilter,
+  BranchFilter,
+  BuildDriverFilter,
+  BuildStateFilter,
+  ProjectFilter,
 } from './FilterModalWidgets'
 import FilterModalWrapper from './FilterModalWrapper'
 import { useRedirectHome } from '../../../hooks/queryHooks'
 
 const ProjectWidgets = ({
-  selectedDrivers, setSelectedDrivers, selectedArtifactKinds, setSelectedArtifactKinds, selectedProjects, setSelectedProjects,
+  selectedArtifactKinds,
+  setSelectedArtifactKinds,
+  selectedProjects,
+  setSelectedProjects,
 }) => (
   <>
     {PROJECTS.filter((p) => p !== PROJECTS.UnknownProject).map((p, i) => (
@@ -28,14 +40,20 @@ const ProjectWidgets = ({
         key={i}
         project={PROJECT[p]}
         {...{
-          selectedDrivers, setSelectedDrivers, selectedArtifactKinds, setSelectedArtifactKinds, selectedProjects, setSelectedProjects,
+          selectedArtifactKinds,
+          setSelectedArtifactKinds,
+          selectedProjects,
+          setSelectedProjects,
         }}
       />
     ))}
   </>
 )
 
-const ArtifactKindWidgets = ({ setSelectedArtifactKinds, selectedArtifactKinds }) => (
+const ArtifactKindWidgets = ({
+  setSelectedArtifactKinds,
+  selectedArtifactKinds,
+}) => (
   <>
     {ARTIFACT_KINDS.map((k, i) => (
       <ArtifactFilter
@@ -90,39 +108,77 @@ const FilterModal = ({ closeAction }) => {
   const [selectedBranches] = useState(['all'])
   const history = useHistory()
 
-
   const tablerOverrides = {
     modalFooterStyle: { borderTop: 'none', justifyContent: 'center' },
-    modalFooterSettingsStyle: { borderTop: 'none', flexWrap: 'wrap', justifyContent: 'flex-end' },
+    modalFooterSettingsStyle: {
+      borderTop: 'none',
+      flexWrap: 'wrap',
+      justifyContent: 'flex-end',
+    },
   }
 
   return (
     <FilterModalWrapper {...{ closeAction }}>
       <div className="modal-body">
-        <div style={{ color: theme.text.sectionTitle }} className={styles.subtitle}>Projects</div>
+        <div
+          style={{ color: theme.text.sectionTitle }}
+          className={styles.subtitle}
+        >
+          Projects
+        </div>
         <div className={styles.row}>
-          <ProjectWidgets {...{
-            selectedDrivers, setSelectedDrivers, selectedArtifactKinds, setSelectedArtifactKinds, selectedProjects, setSelectedProjects,
-          }}
+          <ProjectWidgets
+            {...{
+              selectedDrivers,
+              setSelectedDrivers,
+              selectedArtifactKinds,
+              setSelectedArtifactKinds,
+              selectedProjects,
+              setSelectedProjects,
+            }}
           />
         </div>
-        <div style={{ color: theme.text.sectionTitle }} className={styles.subtitle}>Artifact Kinds</div>
-        <div className={styles.row}>
-          <ArtifactKindWidgets {...{ selectedArtifactKinds, setSelectedArtifactKinds }} />
+        <div
+          style={{ color: theme.text.sectionTitle }}
+          className={styles.subtitle}
+        >
+          Artifact Kinds
         </div>
-        <div style={{ color: theme.text.sectionTitle }} className={styles.subtitle}>Build Drivers</div>
+        <div className={styles.row}>
+          <ArtifactKindWidgets
+            {...{ selectedArtifactKinds, setSelectedArtifactKinds }}
+          />
+        </div>
+        <div
+          style={{ color: theme.text.sectionTitle }}
+          className={styles.subtitle}
+        >
+          Build Drivers
+        </div>
         <div className={styles.row}>
           <BuildDriverWidgets {...{ selectedDrivers, setSelectedDrivers }} />
         </div>
-        <div style={{ color: theme.text.sectionTitle }} className={styles.subtitle}>Branches</div>
+        <div
+          style={{ color: theme.text.sectionTitle }}
+          className={styles.subtitle}
+        >
+          Branches
+        </div>
         <div className={styles.row}>
           <BranchFilter branchName="all" {...{ selectedBranches }} />
           <BranchFilter branchName="master" {...{ selectedBranches }} />
           <BranchFilter branchName="develop" {...{ selectedBranches }} />
         </div>
-        <div style={{ color: theme.text.sectionTitle }} className={styles.subtitle}>Build State</div>
+        <div
+          style={{ color: theme.text.sectionTitle }}
+          className={styles.subtitle}
+        >
+          Build State
+        </div>
         <div className={styles.row}>
-          <BuildStateWidgets {...{ selectedBuildStates, setSelectedBuildStates }} />
+          <BuildStateWidgets
+            {...{ selectedBuildStates, setSelectedBuildStates }}
+          />
         </div>
       </div>
       <div className="modal-footer" style={tablerOverrides.modalFooterStyle}>
@@ -131,7 +187,10 @@ const FilterModal = ({ closeAction }) => {
           className="btn btn-primary"
           data-dismiss="modal"
           onClick={() => {
-            window.localStorage.setItem("projects", JSON.stringify([...selectedProjects]))
+            window.localStorage.setItem(
+              'projects',
+              JSON.stringify([...selectedProjects]),
+            )
             updateState({
               isLoaded: false,
               needsRefresh: true,
@@ -145,16 +204,12 @@ const FilterModal = ({ closeAction }) => {
               build_state: selectedBuildStates,
               artifact_kinds: selectedArtifactKinds,
             }
-            window.localStorage.setItem("uiFilters", JSON.stringify(uiFilters))
+            window.localStorage.setItem('uiFilters', JSON.stringify(uiFilters))
             history.push({
               path: '/',
-              search: queryString
-                .stringify(
-                  _.pickBy(
-                    uiFilters,
-                    (val) => getIsArrayWithN(val, 1),
-                  ),
-                ),
+              search: queryString.stringify(
+                _.pickBy(uiFilters, (val) => getIsArrayWithN(val, 1)),
+              ),
             })
           }}
           style={themeStyles.primaryButtonColors}
@@ -163,7 +218,10 @@ const FilterModal = ({ closeAction }) => {
           Apply Filters
         </div>
       </div>
-      <div className="modal-footer settings" style={tablerOverrides.modalFooterSettingsStyle}>
+      <div
+        className="modal-footer settings"
+        style={tablerOverrides.modalFooterSettingsStyle}
+      >
         <ThemeToggler />
         <Tag
           onClick={() => {

--- a/web/src/ui/components/FilterModal/FilterModalWidgets.js
+++ b/web/src/ui/components/FilterModal/FilterModalWidgets.js
@@ -8,7 +8,6 @@ import {
   BUILD_STATE_VALUE_TO_NAME,
   PROJECT,
   PROJECT_ARTIFACT_KINDS,
-  PROJECT_BUILD_DRIVER,
   PROJECT_NAME,
 } from '../../../constants'
 import { addOrRemoveFromArray } from '../../../util/getters'
@@ -43,14 +42,11 @@ export const ProjectFilter = ({
   project,
   selectedProjects,
   setSelectedProjects,
-  selectedDrivers,
-  setSelectedDrivers,
   selectedArtifactKinds,
   setSelectedArtifactKinds,
 }) => {
   const selected = selectedProjects.includes(project)
   const artifactKindsForProject = !!PROJECT_ARTIFACT_KINDS[project]
-  const buildDriverForProject = PROJECT_BUILD_DRIVER[project]
   const projectValue = PROJECT[project] || 'Unknown Project'
   const ownerIcon = getOwnerIcon(projectValue)
 
@@ -62,8 +58,6 @@ export const ProjectFilter = ({
           ...PROJECT_ARTIFACT_KINDS[projectValue],
         ]),
       )
-    buildDriverForProject
-      && setSelectedDrivers(uniq([...selectedDrivers, buildDriverForProject]))
     setSelectedProjects(uniq([...selectedProjects, projectValue]))
   }
 


### PR DESCRIPTION
On navigation to home with no query params (assuming you have nothing in localStorage):

- Removes default build driver param
- Adds plaintext messenger URL as default `project_id` query param
- As before: Keeps default behavior of using useragent to detect artifact kind if on mobile; otherwise defaults to IPA only

- Also removes association everywhere between filters on build drivers<->project (selecting a project in UI will no longer append specific build drivers to query, as before)

nb:

- There are some pre-existing strange behaviors with localStorage vs. nav bar query params not addressed in this MR.
- Manually adding `project_id=__BERTY URL__` in nav bar will not update UI Filters (i.e. add the berdy logo in header – you must select Messenger via filters modal for that)

-----------

chore: update default options

Signed-off-by: Manfred Touron <94029+moul@users.noreply.github.com>

remove build driver associations with projects

lint and add messenger project id url as default query param

Signed-off-by: Elizabeth Kelen <erskelen@gmail.com>

------------

Closes #386 