### PR TITLE
fix(js): remove renamed env var from react app

### DIFF
--- a/web/src/api/requests.js
+++ b/web/src/api/requests.js
@@ -4,7 +4,7 @@ import queryString from "query-string";
 export const buildListRequest = ({ apiKey = "", queryObject = {} }) => {
   const options = {
     method: "get",
-    baseURL: `${process.env.REACT_APP_API_SERVER}/api/build-list`,
+    baseURL: `https://yolo.berty.io/api/build-list`,
     params: { ...queryObject },
 
     paramsSerializer: (params) => queryString.stringify(params),
@@ -12,13 +12,17 @@ export const buildListRequest = ({ apiKey = "", queryObject = {} }) => {
       Authorization: `Basic ${apiKey}`,
     },
   };
+  console.warn(
+    `${process.env.REACT_APP_API_SERVER} === https://yolo.berty.io ? `,
+    process.env.REACT_APP_API_SERVER === "https://yolo.berty.io"
+  );
   return axios(options);
 };
 
 export const ping = ({ apiKey = "" }) => {
   const options = {
     method: "get",
-    baseURL: `${process.env.REACT_APP_API_SERVER}/api/ping`,
+    baseURL: `https://yolo.berty.io/api/ping`,
     headers: {
       Authorization: `Basic ${apiKey}`,
     },

--- a/web/src/ui/components/Build/ArtifactRow.js
+++ b/web/src/ui/components/Build/ArtifactRow.js
@@ -29,7 +29,7 @@ const ArtifactRowKindIcon = ({ color, kind = "" }) => (
 export const QrCode = ({ artifactPlistSignedUrl, closeAction }) => (
   <QRCodeModal closeAction={closeAction}>
     <QRCode
-      value={`itms-services://?action=download-manifest&url=${process.env.REACT_APP_API_SERVER}${artifactPlistSignedUrl}`}
+      value={`itms-services://?action=download-manifest&url=https://yolo.berty.io${artifactPlistSignedUrl}`}
       // size={256}
       level="M"
       renderAs="svg"
@@ -58,10 +58,10 @@ const ArtifactDownloadButton = ({
   const { theme } = useContext(ThemeContext);
   const fullPlistSignedUrl =
     artifactPlistSignedUrl &&
-    `itms-services://?action=download-manifest&url=${process.env.REACT_APP_API_SERVER}${artifactPlistSignedUrl}`;
+    `itms-services://?action=download-manifest&url=https://yolo.berty.io${artifactPlistSignedUrl}`;
   const fullDlArtifactSignedUrl =
     artifactDlArtifactSignedUrl &&
-    `${process.env.REACT_APP_API_SERVER}${artifactDlArtifactSignedUrl}`;
+    `${process.env.API_SERVER}${artifactDlArtifactSignedUrl}`;
   const hasDlUrl = fullPlistSignedUrl || fullDlArtifactSignedUrl;
 
   return (

--- a/web/src/ui/components/Build/BuildContainer.js
+++ b/web/src/ui/components/Build/BuildContainer.js
@@ -111,11 +111,11 @@ const DlButtonSmall = ({ buildHasArtifacts, theme }) =>
 
         const fullPlistSignedUrl =
           artifactPlistSignedUrl &&
-          `itms-services://?action=download-manifest&url=${process.env.REACT_APP_API_SERVER}${artifactPlistSignedUrl}`;
+          `itms-services://?action=download-manifest&url=https://yolo.berty.io${artifactPlistSignedUrl}`;
 
         const fullDlArtifactSignedUrl =
           artifactDlArtifactSignedUrl &&
-          `${process.env.REACT_APP_API_SERVER}${artifactDlArtifactSignedUrl}`;
+          `https://yolo.berty.io${artifactDlArtifactSignedUrl}`;
 
         const hasDlUrl = fullPlistSignedUrl || fullDlArtifactSignedUrl;
         return (


### PR DESCRIPTION
CRA-friendly `REACT_APP_API_SERVER` env variable doesn't seem to be recognized in production. 🤔

Signed-off-by: Elizabeth Kelen <erskelen@gmail.com>